### PR TITLE
Drop .NET Core 2.0 targeting in test project

### DIFF
--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -21,14 +21,6 @@ steps:
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - task: DotNetCoreCLI@2
-  displayName: dotnet test -f netcoreapp2.0
-  inputs:
-    command: test
-    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.0 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true
-    testRunTitle: netcoreapp2.0-$(Agent.JobName)
-    workingDirectory: src
-
-- task: DotNetCoreCLI@2
   displayName: dotnet test -f netcoreapp2.1
   inputs:
     command: test

--- a/src/Library.Tests/CalculatorTests.cs
+++ b/src/Library.Tests/CalculatorTests.cs
@@ -18,8 +18,8 @@ public class CalculatorTests
     [Fact]
     public void AddOrSubtract()
     {
-        // This tests aggregation of code coverage.
-#if NETCOREAPP2_0
+        // This tests aggregation of code coverage across test runs.
+#if NETCOREAPP2_1
         Assert.Equal(3, Calculator.Add(1, 2));
 #else
         Assert.Equal(-1, Calculator.Subtract(1, 2));

--- a/src/Library.Tests/Library.Tests.csproj
+++ b/src/Library.Tests/Library.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
Microsoft's long-term support for .NET Core 1.x and 2.0 [are over][LTS]. Customers targeting these versions are in a really bad place due to no security patches being offered and thus there are likely few to none out there.

[LTS]: https://github.com/dotnet/core/blob/e2f22a7106860c0e5dc98bb36dc648a779944ad5/microsoft-support.md#net-core-releases