### PR TITLE
Use a local package cache

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <config>
+    <add key="globalPackagesFolder" value="obj\.nuget\packages" />
+  </config>
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />


### PR DESCRIPTION
This ensures that restore always uses the sources in nuget.config rather than a cache that happens to be on the local box. It helps avoid bugs that are not caught till a build suddenly fails on some machine somewhere because it didn't happen to have a package cached locally from some other source.
It also mitigates the risk on private build agents that a package cache is "poisoned" by some build already done on that agent with other package sources where the id/version of a package collides but the contents are not actually identical.