### PR TITLE
Use AGENT_TEMPDIRECTORY for tools

### DIFF
--- a/azure-pipelines/Get-TempToolsPath.ps1
+++ b/azure-pipelines/Get-TempToolsPath.ps1
@@ -1,7 +1,7 @@
-if ($env:AGENT_TOOLSDIRECTORY) {
-    $path = "$env:AGENT_TOOLSDIRECTORY\vs-platform\tools"
+if ($env:AGENT_TEMPDIRECTORY) {
+    $path = "$env:AGENT_TEMPDIRECTORY\$env:BUILD_BUILDID"
 } elseif ($env:localappdata) {
-    $path = "$env:localappdata\vs-platform\tools"
+    $path = "$env:localappdata\gitrepos\tools"
 } else {
     $path = "$PSScriptRoot\..\obj\tools"
 }

--- a/azure-pipelines/Get-nbgv.ps1
+++ b/azure-pipelines/Get-nbgv.ps1
@@ -10,11 +10,7 @@ if ($existingTool) {
     return $existingTool.Path
 }
 
-if ($env:AGENT_TEMPDIRECTORY) {
-    $toolInstallDir = "$env:AGENT_TEMPDIRECTORY/$env:BUILD_BUILDID"
-} else {
-    $toolInstallDir = "$PSScriptRoot/../obj/tools"
-}
+$toolInstallDir = & "$PSScriptRoot/Get-TempToolsPath.ps1"
 
 $toolPath = "$toolInstallDir/nbgv"
 if (!(Test-Path $toolInstallDir)) { New-Item -Path $toolInstallDir -ItemType Directory | Out-Null }


### PR DESCRIPTION
AGENT_TOOLSDIRECTORY may not be cleaned between each build, so AGENT_TEMPDIRECTORY which certainly is cleaned is a better place to put files that might need newer versions downloaded and/or installed each time.