### PR TITLE
Upgrade NuGet credprovider in Azure Pipelines

### DIFF
--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -4,7 +4,7 @@ parameters:
 steps:
 
 - powershell: |
-    .\init.ps1 -AccessToken '$(System.AccessToken)' ${{ parameters['initArgs'] }}
+    .\init.ps1 -AccessToken '$(System.AccessToken)' ${{ parameters['initArgs'] }} -UpgradePrerequisites
     dotnet --info
   displayName: Install prerequisites
 

--- a/init.ps1
+++ b/init.ps1
@@ -15,6 +15,9 @@ Per-repo can lead to file locking issues when dotnet.exe is left running as a bu
 Per-machine requires elevation and will download and install all SDKs and runtimes to machine-wide locations so all applications can find it.
 .PARAMETER NoPrerequisites
 Skips the installation of prerequisite software (e.g. SDKs, tools).
+.PARAMETER UpgradePrerequisites
+Takes time to install prerequisites even if they are already present in case they need to be upgraded.
+No effect if -NoPrerequisites is specified.
 .PARAMETER NoRestore
 Skips the package restore step.
 .PARAMETER AccessToken
@@ -27,13 +30,15 @@ Param (
     [Parameter()]
     [switch]$NoPrerequisites,
     [Parameter()]
+    [switch]$UpgradePrerequisites,
+    [Parameter()]
     [switch]$NoRestore,
     [Parameter()]
     [string]$AccessToken
 )
 
 if (!$NoPrerequisites) {
-    & "$PSScriptRoot\tools\Install-NuGetCredProvider.ps1" -AccessToken $AccessToken
+    & "$PSScriptRoot\tools\Install-NuGetCredProvider.ps1" -AccessToken $AccessToken -Force:$UpgradePrerequisites
     & "$PSScriptRoot\tools\Install-DotNetSdk.ps1" -InstallLocality $InstallLocality
 }
 

--- a/tools/Install-NuGetCredProvider.ps1
+++ b/tools/Install-NuGetCredProvider.ps1
@@ -4,11 +4,15 @@
     from https://github.com/microsoft/artifacts-credprovider
     to assist in authenticating to Azure Artifact feeds in interactive development
     or unattended build agents.
+.PARAMETER Force
+    Forces install of the CredProvider plugin even if one already exists. This is useful to upgrade an older version.
 .PARAMETER AccessToken
     An optional access token for authenticating to Azure Artifacts authenticated feeds.
 #>
 [CmdletBinding()]
 Param (
+    [Parameter()]
+    [switch]$Force,
     [Parameter()]
     [string]$AccessToken
 )
@@ -35,7 +39,7 @@ if ($IsMacOS -or $IsLinux) {
     chmod u+x $installerScript
 }
 
-& $installerScript
+& $installerScript -Force:$Force
 
 if ($AccessToken) {
     $endpoints = @()


### PR DESCRIPTION
On private agents where it may exist from a prior build, it's important that we update it to whatever the latest version is.