### PR TITLE
Use agent jobname for for symbols folder

### DIFF
--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -49,7 +49,7 @@ steps:
 
 - task: PublishSymbols@2
   inputs:
-    SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols-Windows
+    SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols-$(Agent.JobName)
     SearchPattern: '**/*.pdb'
     IndexSources: false
     SymbolServerType: TeamServices


### PR DESCRIPTION
A suggestion to use Agent.JobName variable for symbols folder name to be consistent and to avoid potential bugs when adapting the template with a different job name.