### PR TITLE
Collect dumps and sequence.xml files on test hangs and crashes

### DIFF
--- a/.github/workflows/Linux.runsettings
+++ b/.github/workflows/Linux.runsettings
@@ -1,0 +1,1 @@
+<RunSettings />

--- a/.github/workflows/Windows.runsettings
+++ b/.github/workflows/Windows.runsettings
@@ -1,0 +1,14 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="blame" enabled="True">
+        <Configuration>
+          <CollectDump DumpType="full" />
+          <CollectDumpOnTestSessionHang TestTimeout="30000" DumpType="full" />
+          <!-- This ResultsDirectory must exist, but it is totally ignored. -->
+          <ResultsDirectory>%GITHUB_WORKSPACE%</ResultsDirectory>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ jobs:
       run: |
         ./init.ps1 -UpgradePrerequisites
         dotnet --info
+        if ($env:RUNNER_OS -eq "Windows") {
+          choco install procdump
+          Write-Host "##[set-env name=PROCDUMP_PATH;]$env:PROGRAMDATA\chocolatey\bin\"
+        }
       shell: pwsh
     - name: Set pipeline variables based on source
       run: azure-pipelines/variables/_pipelines.ps1
@@ -43,7 +47,7 @@ jobs:
     - name: pack
       run: dotnet pack src --no-build -c ${{ env.BUILDCONFIGURATION }} /v:m /bl:"bin/build_logs/pack.binlog"
     - name: test
-      run: dotnet test src --no-build -c ${{ env.BUILDCONFIGURATION }} /bl:"bin/build_logs/test.binlog" --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true
+      run: dotnet test src --no-build -c ${{ env.BUILDCONFIGURATION }} /bl:"bin/build_logs/test.binlog" --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --logger trx --settings "${{ github.workspace }}/.github/workflows/${{ runner.os }}.runsettings"
     - name: Update pipeline variables based on build outputs
       run: azure-pipelines/variables/_pipelines.ps1
       shell: pwsh
@@ -71,6 +75,13 @@ jobs:
       with:
         name: build_logs-${{ runner.os }}
         path: obj/_artifacts/build_logs
+      continue-on-error: true
+    - name: Upload testResults
+      if: always()
+      uses: actions/upload-artifact@v1
+      with:
+        name: testResults-${{ runner.os }}
+        path: obj/_artifacts/testResults
       continue-on-error: true
     - name: Upload coverageResults
       if: always()

--- a/.github/workflows/macOS.runsettings
+++ b/.github/workflows/macOS.runsettings
@@ -1,0 +1,1 @@
+<RunSettings />

--- a/azure-pipelines/Darwin.runsettings
+++ b/azure-pipelines/Darwin.runsettings
@@ -1,0 +1,1 @@
+<RunSettings />

--- a/azure-pipelines/Linux.runsettings
+++ b/azure-pipelines/Linux.runsettings
@@ -1,0 +1,1 @@
+<RunSettings />

--- a/azure-pipelines/Windows_NT.runsettings
+++ b/azure-pipelines/Windows_NT.runsettings
@@ -1,0 +1,14 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="blame" enabled="True">
+        <Configuration>
+          <CollectDump DumpType="full" />
+          <CollectDumpOnTestSessionHang TestTimeout="30000" DumpType="full" />
+          <!-- This ResultsDirectory must exist, but it is totally ignored. -->
+          <ResultsDirectory>%BUILD_ARTIFACTSTAGINGDIRECTORY%</ResultsDirectory>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/azure-pipelines/artifacts/testResults.ps1
+++ b/azure-pipelines/artifacts/testResults.ps1
@@ -1,0 +1,12 @@
+if ($env:AGENT_TEMPDIRECTORY) {
+    # The DotNetCoreCLI uses an alternate location to publish these files
+    $guidRegex = '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'
+    @{
+        $env:AGENT_TEMPDIRECTORY = (Get-ChildItem $env:AGENT_TEMPDIRECTORY -Directory |? { $_.Name -match $guidRegex } |% { Get-ChildItem "$($_.FullName)\testhost.*.dmp","$($_.FullName)\Sequence_*.xml" -Recurse });
+    }
+} else {
+    $srcRoot = Resolve-Path "$PSScriptRoot\..\..\src"
+    @{
+        $srcRoot = (Get-ChildItem "$srcRoot\TestResults" -Recurse -Directory | Get-ChildItem -Recurse -File);
+    }
+}

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -12,7 +12,7 @@ steps:
   displayName: dotnet test -f net472
   inputs:
     command: test
-    arguments: --no-build -c $(BuildConfiguration) -f net472 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true
+    arguments: --no-build -c $(BuildConfiguration) -f net472 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
     testRunTitle: net472-$(Agent.JobName)
     workingDirectory: src
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
@@ -21,7 +21,7 @@ steps:
   displayName: dotnet test -f netcoreapp2.1
   inputs:
     command: test
-    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true
+    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
     testRunTitle: netcoreapp2.1-$(Agent.JobName)
     workingDirectory: src
 
@@ -29,7 +29,7 @@ steps:
   displayName: dotnet test -f netcoreapp3.1
   inputs:
     command: test
-    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp3.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true
+    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp3.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
     testRunTitle: netcoreapp3.1-$(Agent.JobName)
     workingDirectory: src
 

--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -8,6 +8,13 @@ steps:
     dotnet --info
   displayName: Install prerequisites
 
+# The procdump tool and env var is required for dotnet test to collect hang/crash dumps of tests.
+- powershell: |
+    choco install procdump
+    Write-Host "##vso[task.setvariable variable=PROCDUMP_PATH;]$env:ProgramData\chocolatey\bin\"
+  displayName: Install procdump
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
 - task: PowerShell@2
   inputs:
     filePath: azure-pipelines/variables/_pipelines.ps1


### PR DESCRIPTION
This makes diagnosing test runner crashes and hangs on Azure Pipelines and GitHub Actions possible.
After such a failure, a testResults artifact is collected that includes the `Sequence_*.xml` and `testhost.*.dmp` files collected at the timeout or crash.
These files can then be downloaded from the CI/PR artifacts for study.

Dumps are only collected on Windows agents. Collecting dumps on other OS's is not supported by the test runner.