### PR TITLE
Acquire procdump via nuget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,6 @@ jobs:
       run: |
         ./init.ps1 -UpgradePrerequisites
         dotnet --info
-        if ($env:RUNNER_OS -eq "Windows") {
-          choco install procdump -y
-          Write-Host "##[set-env name=PROCDUMP_PATH;]$env:PROGRAMDATA\chocolatey\bin\"
-        }
       shell: pwsh
     - name: Set pipeline variables based on source
       run: azure-pipelines/variables/_pipelines.ps1

--- a/azure-pipelines/Get-ProcDump.ps1
+++ b/azure-pipelines/Get-ProcDump.ps1
@@ -1,0 +1,14 @@
+<#
+.SYNOPSIS
+Downloads 32-bit and 64-bit procdump executables and returns the path to where they were installed.
+#>
+$version = '0.0.1'
+$baseDir = "$PSScriptRoot\..\obj\tools"
+$procDumpToolPath = "$baseDir\procdump.$version\bin"
+if (-not (Test-Path $procDumpToolPath)) {
+    if (-not (Test-Path $baseDir)) { New-Item -Type Directory -Path $baseDir | Out-Null }
+    $baseDir = (Resolve-Path $baseDir).Path # Normalize it
+    & (& $PSScriptRoot\Get-NuGetTool.ps1) install procdump -version $version -PackageSaveMode nuspec -OutputDirectory $baseDir -Source https://api.nuget.org/v3/index.json | Out-Null
+}
+
+(Resolve-Path $procDumpToolPath).Path

--- a/azure-pipelines/Set-EnvVars.ps1
+++ b/azure-pipelines/Set-EnvVars.ps1
@@ -24,7 +24,7 @@ if ($cmdInstructions) {
     Write-Host "Environment variables that must be set manually:" -ForegroundColor Blue
 } else {
     Write-Host "Environment variables set:" -ForegroundColor Blue
-    $envVars
+    Write-Host ($Variables | Out-String)
     if ($PrependPath) {
         Write-Host "Paths prepended to PATH: $PrependPath"
     }

--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -8,13 +8,6 @@ steps:
     dotnet --info
   displayName: Install prerequisites
 
-# The procdump tool and env var is required for dotnet test to collect hang/crash dumps of tests.
-- powershell: |
-    choco install procdump -y
-    Write-Host "##vso[task.setvariable variable=PROCDUMP_PATH;]$env:ProgramData\chocolatey\bin\"
-  displayName: Install procdump
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
-
 - powershell: azure-pipelines/variables/_pipelines.ps1
   failOnStderr: true
   displayName: Set pipeline variables based on source


### PR DESCRIPTION
Just using nuget instead of choco makes it take less than 1 second instead of nearly a minute.
It also removes the requirement for chocolatey to be installed on AzP agents, which helps compatibility with custom/private agents.

Also move it to init.ps1 so it doesn't require a special AzP or GitHub Actions task and it canl run on local dev boxes.