### PR TITLE
Use SignType parameter instead of variable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,3 +20,5 @@ variables:
 
 jobs:
 - template: azure-pipelines/build.yml
+  parameters:
+    SignType:

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,5 +1,8 @@
 parameters:
-  windowsPool: Hosted Windows 2019 with VS2019
+- name: windowsPool
+  type: string
+  default: Hosted Windows 2019 with VS2019
+- name: SignType
 
 jobs:
 - job: Windows
@@ -14,6 +17,8 @@ jobs:
 
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
     - template: microbuild.before.yml
+      parameters:
+        SignType: ${{ parameters.SignType }}
 
   - template: dotnet.yml
 

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -1,6 +1,9 @@
+parameters:
+- name: SignType
+
 steps:
 - task: MicroBuildSigningPlugin@2
   inputs:
-    signType: $(SignType)
+    signType: ${{ parameters.SignType }}
     zipSources: false
   displayName: Install MicroBuild Signing Plugin

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -10,6 +10,13 @@ trigger:
     - '*.md'
     - .vscode/
 
+parameters:
+- name: SignType
+  displayName: Sign type
+  type: string
+  default: Test
+  values: [ 'Test', 'Real' ]
+
 variables:
   TreatWarningsAsErrors: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -17,8 +24,10 @@ variables:
   BuildPlatform: Any CPU
   push_to_ci: true
   NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages
+  SignType: ${{ parameters.SignType }}
 
 jobs:
 - template: build.yml
   parameters:
     windowsPool: VSEng-MicroBuildVS2019
+    SignType: ${{ parameters.SignType }}

--- a/azure-pipelines/variables/SignType.ps1
+++ b/azure-pipelines/variables/SignType.ps1
@@ -1,3 +1,0 @@
-if ($env:SYSTEM_COLLECTIONID -eq '011b8bdf-6d56-4f87-be0d-0092136884d9') {
-  'test'
-}

--- a/azure-pipelines/variables/ci_feed.ps1
+++ b/azure-pipelines/variables/ci_feed.ps1
@@ -1,7 +1,4 @@
-$signType = $env:SIGNTYPE
-if (!$signType) { $signType = & "$PSScriptRoot/SignType.ps1" }
-
-if ($signType -eq 'Real') {
+if ($env:SIGNTYPE -eq 'Real') {
     '09d8d03c-1ac8-456e-9274-4d2364527d99' # VSIDE-RealSigned-Release
 } else {
     'da484c78-f942-44ef-b197-99e2a1bef53c' # VSIDE-TestSigned-Release


### PR DESCRIPTION
This presents this beautiful UI in Azure Pipelines when queuing:

![image](https://user-images.githubusercontent.com/3548/79628446-5be4ef00-80fe-11ea-9e01-d56057853b44.png)
