### PR TITLE
Avoid unannounced system restart

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.300",
+    "version": "3.1.301",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/init.ps1
+++ b/init.ps1
@@ -44,6 +44,9 @@ $EnvVars = @{}
 if (!$NoPrerequisites) {
     & "$PSScriptRoot\tools\Install-NuGetCredProvider.ps1" -AccessToken $AccessToken -Force:$UpgradePrerequisites
     & "$PSScriptRoot\tools\Install-DotNetSdk.ps1" -InstallLocality $InstallLocality
+    if ($LASTEXITCODE -eq 3010) {
+        Exit 3010
+    }
 
     # The procdump tool and env var is required for dotnet test to collect hang/crash dumps of tests.
     # But it only works on Windows.


### PR DESCRIPTION
When installing the .NET SDK or runtime, if the installer wants a system restart, it would do so quietly. This avoids the restart but adds a prompt at the end of the script to inform the user of a restart being required when necessary.

Fixes #57