### PR TITLE
MicroBuild Signing Plugin - "dotnet build" testing

### DIFF
--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -1,16 +1,8 @@
 steps:
 # We use VSBuild instead of "dotnet build" on Windows where MicroBuild tasks have to run (since they don't support MSBuild Core yet).
-- task: VSBuild@1
-  displayName: Build Visual Studio solution
-  inputs:
-    msbuildArgs: /t:build,pack /m /bl:"$(Build.ArtifactStagingDirectory)/build_logs/msbuild.binlog"
-    platform: Any CPU
-    configuration: $(BuildConfiguration)
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - script: dotnet build --no-restore -c $(BuildConfiguration) /v:m /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
   displayName: dotnet build
-  condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT'))
 
 - script: dotnet pack --no-build -c $(BuildConfiguration) /v:m /bl:"$(Build.ArtifactStagingDirectory)/build_logs/pack.binlog"
   displayName: dotnet pack

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -6,7 +6,6 @@ steps:
 
 - script: dotnet pack --no-build -c $(BuildConfiguration) /v:m /bl:"$(Build.ArtifactStagingDirectory)/build_logs/pack.binlog"
   displayName: dotnet pack
-  condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2
   displayName: dotnet test -f net472

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -7,5 +7,5 @@ steps:
     signType: ${{ parameters.SignType }}
     zipSources: false
     version: '1.1.312-gf0d899cd08'
-    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+    feedSource: 'https://pkgs.dev.azure.com/devdiv-test/_packaging/b2f739af-dbd1-43a8-b68c-e319a274ebda/nuget/v2/'
   displayName: Install MicroBuild Signing Plugin

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -7,4 +7,5 @@ steps:
     signType: ${{ parameters.SignType }}
     zipSources: false
     version: '1.1.312-gf0d899cd08'
+    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
   displayName: Install MicroBuild Signing Plugin

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -6,4 +6,5 @@ steps:
   inputs:
     signType: ${{ parameters.SignType }}
     zipSources: false
+    version: '1.1.312-gf0d899cd08'
   displayName: Install MicroBuild Signing Plugin


### PR DESCRIPTION
**MicroBuild Signing Plugin (v1.1.312-gf0d899cd08) - "dotnet build" testing**

Note: FxCop Nuget package included. Old static analysis disabled.