### PR TITLE
Remove macOS from Azure Pipeline runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,12 @@ trigger:
     - .vscode/
     - .github/
 
+parameters:
+- name: includeMacOS
+  displayName: Build on macOS
+  type: boolean
+  default: false # macOS is often bogged down in Azure Pipelines
+
 variables:
   TreatWarningsAsErrors: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -20,3 +26,5 @@ variables:
 
 jobs:
 - template: azure-pipelines/build.yml
+  parameters:
+    includeMacOS: ${{ parameters.includeMacOS }}

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,5 +1,6 @@
 parameters:
   windowsPool: Hosted Windows 2019 with VS2019
+  includeMacOS:
 
 jobs:
 - job: Windows
@@ -26,6 +27,7 @@ jobs:
   - template: expand-template.yml
 
 - job: macOS
+  condition: ${{ parameters.includeMacOS }}
   pool:
     vmImage: macOS-10.15
   steps:
@@ -50,4 +52,6 @@ jobs:
     parameters:
       initArgs: -NoRestore
   - template: publish-codecoverage.yml
+    parameters:
+      includeMacOS: ${{ parameters.includeMacOS }}
   - template: publish-deployables.yml

--- a/azure-pipelines/publish-codecoverage.yml
+++ b/azure-pipelines/publish-codecoverage.yml
@@ -1,3 +1,6 @@
+parameters:
+  includeMacOS:
+
 steps:
 - download: current
   artifact: coverageResults-Windows
@@ -11,6 +14,7 @@ steps:
   artifact: coverageResults-macOS
   displayName: Download macOS code coverage results
   continueOnError: true
+  condition: ${{ parameters.includeMacOS }}
 - powershell: |
     dotnet tool install --tool-path obj dotnet-reportgenerator-globaltool --version 4.2.2 --configfile azure-pipelines/justnugetorg.nuget.config
     Copy-Item -Recurse $(Pipeline.Workspace)/coverageResults-Windows/obj/* $(System.DefaultWorkingDirectory)/obj


### PR DESCRIPTION
A means to 'opt in' to building on macOS remains. And for repos where macOS agents are important to keep in, it's easy to remove the parameter and/or change its default from off to on.