### PR TITLE
Embed PDBs for all local builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,9 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
+    <!-- Local builds should embed PDBs so we never lose them when a subsequent build occurs. -->
+    <DebugType Condition=" '$(CI)' != 'true' and '$(TF_BUILD)' != 'true' ">embedded</DebugType>
+
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\strongname.snk</AssemblyOriginatorKeyFile>
 


### PR DESCRIPTION
This ensures that if you build a dll and copy it somewhere, then build again, you haven't lost the ability to debug the original dll because it carries the pdb with it wherever it goes.
We do *not* embed the pdb in the official builds however because the official builds will archive the pdb so it isn't lost, and it would unnecessarily bloat the assembly.