### PR TITLE
Fixes the Install-DotNetSdk.ps1 script when the path to the repo contains spaces

### DIFF
--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -149,6 +149,12 @@ if ($IsMacOS -or $IsLinux) {
     $DotNetInstallScriptPath = "$DotNetInstallScriptRoot/dotnet-install.ps1"
 }
 
+if ($IsMacOS -or $IsLinux) {
+    $DotNetInstallScriptPath = $DotNetInstallScriptPath.Replace(' ', '\ ')
+} else {
+    $DotNetInstallScriptPath = $DotNetInstallScriptPath.Replace(' ', '` ')
+}
+
 if (-not (Test-Path $DotNetInstallScriptPath)) {
     Invoke-WebRequest -Uri $DownloadUri -OutFile $DotNetInstallScriptPath -UseBasicParsing
     if ($IsMacOS -or $IsLinux) {

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -152,7 +152,7 @@ if ($IsMacOS -or $IsLinux) {
 if (-not (Test-Path $DotNetInstallScriptPath)) {
     Invoke-WebRequest -Uri $DownloadUri -OutFile $DotNetInstallScriptPath -UseBasicParsing
     if ($IsMacOS -or $IsLinux) {
-        chmod +x $DotNetInstallScriptPath.Replace(' ', '\ ')
+        chmod +x $DotNetInstallScriptPath
     }
 }
 

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -158,7 +158,7 @@ if (-not (Test-Path $DotNetInstallScriptPath)) {
 
 # In case the script we invoke is in a directory with spaces, wrap it with single quotes.
 # In case the path includes single quotes, escape them.
-$DotNetInstallScriptPathExpression = $DotNetInstallScriptPath.Replace("'", "``'") # escape the ` because we need ` to appear in the eventual string.
+$DotNetInstallScriptPathExpression = $DotNetInstallScriptPath.Replace("'", "''")
 $DotNetInstallScriptPathExpression = "& '$DotNetInstallScriptPathExpression'"
 
 $anythingInstalled = $false

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -142,10 +142,10 @@ if ($DotNetInstallDir) {
 }
 
 if ($IsMacOS -or $IsLinux) {
-    $DownloadUri = "https://raw.githubusercontent.com/dotnet/install-scripts/7a9d5dcab92cf131fc2d8977052f8c2c2d540e22/src/dotnet-install.sh"
+    $DownloadUri = "https://raw.githubusercontent.com/dotnet/install-scripts/49d5da7f7d313aa65d24fe95cc29767faef553fd/src/dotnet-install.sh"
     $DotNetInstallScriptPath = "$DotNetInstallScriptRoot/dotnet-install.sh"
 } else {
-    $DownloadUri = "https://raw.githubusercontent.com/dotnet/install-scripts/7a9d5dcab92cf131fc2d8977052f8c2c2d540e22/src/dotnet-install.ps1"
+    $DownloadUri = "https://raw.githubusercontent.com/dotnet/install-scripts/49d5da7f7d313aa65d24fe95cc29767faef553fd/src/dotnet-install.ps1"
     $DotNetInstallScriptPath = "$DotNetInstallScriptRoot/dotnet-install.ps1"
 }
 

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -136,7 +136,7 @@ if ($InstallLocality -eq 'machine') {
 Write-Host "Installing .NET Core SDK and runtimes to $DotNetInstallDir" -ForegroundColor Blue
 
 if ($DotNetInstallDir) {
-    $switches += '-InstallDir',$DotNetInstallDir
+    $switches += '-InstallDir',"`"$DotNetInstallDir`""
     $envVars['DOTNET_MULTILEVEL_LOOKUP'] = '0'
     $envVars['DOTNET_ROOT'] = $DotNetInstallDir
 }


### PR DESCRIPTION
As reported in https://github.com/neuecc/MessagePack-CSharp/issues/1244