### PR TITLE
Add support for TargetFrameworks of the form netXX

### DIFF
--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -51,6 +51,15 @@ Get-ChildItem "$PSScriptRoot\..\src\*.*proj","$PSScriptRoot\..\test\*.*proj","$P
             $windowsDesktopRuntimeVersions += $v
         }
     }
+	
+	# Add target frameworks of the form: netXX
+	$targetFrameworks |? { $_ -match 'net(\d+\.\d+)' } |% {
+        $v = $Matches[1]
+        $runtimeVersions += $v
+        if (-not ($IsMacOS -or $IsLinux)) {
+            $windowsDesktopRuntimeVersions += $v
+        }
+	}
 }
 
 Function Get-FileFromWeb([Uri]$Uri, $OutDir) {


### PR DESCRIPTION
Add support for TargetFrameworks of the form netXX to the Dotnet SDK installer script.  I'm working on a project where I want tests to support the net5 and net6 target frameworks.  When I set global.json to net6, the runtimes for the test projects fail to pick up net5.  This fix adds support for detecting target framework runtimes of the form netXX.