### PR TITLE
Enable Component Governance to PR builds

### DIFF
--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -11,7 +11,6 @@ steps:
 
 - task: ComponentGovernanceComponentDetection@0
   displayName: Component Detection
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
 - task: Ref12Analyze@0
   displayName: Ref12 (Codex) Analyze


### PR DESCRIPTION
It actually does something useful, and will soon be mandated.