### PR TITLE
Fix ARM detection on Linux

### DIFF
--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -29,8 +29,7 @@ $DotNetInstallScriptRoot = Resolve-Path $DotNetInstallScriptRoot
 # Look up actual required .NET Core SDK version from global.json
 $sdkVersion = & "$PSScriptRoot/../azure-pipelines/variables/DotNetSdkVersion.ps1"
 
-$arch = 'x64'
-if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { $arch = 'ARM64' }
+$arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
 
 # Search for all .NET Core runtime versions referenced from MSBuild projects and arrange to install them.
 $runtimeVersions = @()


### PR DESCRIPTION
The `$env:PROCESSOR_ARCHITECTURE` environment variable simply isn't set on linux.