### PR TITLE
Quit using deployment jobs for releases

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -13,60 +13,53 @@ stages:
 - stage: GitHubRelease
   displayName: GitHub Release
   jobs:
-  - deployment: create
+  - job: create
     pool:
       vmImage: ubuntu-latest
-    environment: No-Approval
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - download: none
-          - powershell: |
-              Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
-            displayName: Set pipeline name
-          - task: GitHubRelease@1
-            displayName: GitHub release (create)
-            inputs:
-              gitHubConnection: # TODO: fill in service connection here
-              repositoryName: $(Build.Repository.Name)
-              target: $(resources.pipeline.CI.sourceCommit)
-              tagSource: userSpecifiedTag
-              tag: v$(resources.pipeline.CI.runName)
-              title: v$(resources.pipeline.CI.runName)
-              isDraft: true # After running this step, visit the new draft release, edit, and publish.
-              changeLogCompareToRelease: lastNonDraftRelease
-              changeLogType: issueBased
-              changeLogLabels: |
-                [
-                  { "label" : "bug", "displayName" : "Fixes", "state" : "closed" },
-                  { "label" : "enhancement", "displayName": "Enhancements", "state" : "closed" }
-                ]
+    steps:
+    - checkout: none
+    - powershell: |
+        Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
+      displayName: Set pipeline name
+    - task: GitHubRelease@1
+      displayName: GitHub release (create)
+      inputs:
+        gitHubConnection: # TODO: fill in service connection here
+        repositoryName: $(Build.Repository.Name)
+        target: $(resources.pipeline.CI.sourceCommit)
+        tagSource: userSpecifiedTag
+        tag: v$(resources.pipeline.CI.runName)
+        title: v$(resources.pipeline.CI.runName)
+        isDraft: true # After running this step, visit the new draft release, edit, and publish.
+        changeLogCompareToRelease: lastNonDraftRelease
+        changeLogType: issueBased
+        changeLogLabels: |
+          [
+            { "label" : "bug", "displayName" : "Fixes", "state" : "closed" },
+            { "label" : "enhancement", "displayName": "Enhancements", "state" : "closed" }
+          ]
 
 - stage: nuget_org
   displayName: nuget.org
   dependsOn: GitHubRelease
   jobs:
-  - deployment: push
+  - job: push
     pool:
       vmImage: ubuntu-latest
-    environment: No-Approval
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - download: CI
-            artifact: deployables-Windows
-            displayName: Download deployables-Windows artifact
-            patterns: 'deployables-Windows/*'
-          - task: NuGetToolInstaller@1
-            displayName: Use NuGet 5.x
-            inputs:
-              versionSpec: 5.x
-          - task: NuGetCommand@2
-            displayName: NuGet push
-            inputs:
-              command: push
-              packagesToPush: $(Pipeline.Workspace)/CI/deployables-Windows/*.nupkg
-              nuGetFeedType: external
-              publishFeedCredentials: # TODO: fill in service connection here
+    steps:
+    - checkout: none
+    - download: CI
+      artifact: deployables-Windows
+      displayName: Download deployables-Windows artifact
+      patterns: 'deployables-Windows/*'
+    - task: NuGetToolInstaller@1
+      displayName: Use NuGet 5.x
+      inputs:
+        versionSpec: 5.x
+    - task: NuGetCommand@2
+      displayName: NuGet push
+      inputs:
+        command: push
+        packagesToPush: $(Pipeline.Workspace)/CI/deployables-Windows/*.nupkg
+        nuGetFeedType: external
+        publishFeedCredentials: # TODO: fill in service connection here


### PR DESCRIPTION
These releases aren't to a hosted server environment anyway, so the unique benefits of using deployment jobs don't apply. Yet using them means the user has to create a `No-Approval` environment as a no-op. So switching to ordinary jobs makes the most sense, IMO.

* [ ] Test this change with a real pipeline instance to ensure I made the changes correctly.