### PR TITLE
Activate msbuild 17's platform negotiation feature

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 
+    <!-- https://github.com/dotnet/msbuild/blob/main/documentation/ProjectReference-Protocol.md#setplatform-negotiation -->
+    <EnableDynamicPlatformResolution>true</EnableDynamicPlatformResolution>
+    <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
+
     <!-- This entire repo has just one version.json file, so compute the version once and share with all projects in a large build. -->
     <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
 
@@ -35,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.73-alpha" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.85-alpha" PrivateAssets="all" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
     <!-- Use the Unstable package ID so that update tools will help us keep it current even though it seems to be ever-unstable lately. -->
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.406" PrivateAssets="all" />


### PR DESCRIPTION
Not that this template repo itself requires it, but it's a great baseline to start with as it means the repo will grow nicely as it gets more complicated for real projects.