### PR TITLE
Remove explicit Microsoft.NETFramework.ReferenceAssemblies PackageReference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.85-alpha" PrivateAssets="all" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />


### PR DESCRIPTION
If this builds, I guess we don't need it any more. The SDK is supposed to implicitly reference it, but we added it back when there were certain TFMs or SDK version that didn't actually do it.