### PR TITLE
Test on .NET 6 instead of .NET 5

### DIFF
--- a/test/Library.Tests/Library.Tests.csproj
+++ b/test/Library.Tests/Library.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net472</TargetFrameworks>
     <RootNamespace />
   </PropertyGroup>
 


### PR DESCRIPTION
.NET 5 falls out of Microsoft support in just a few days, so folks should focus testing on the currently supported platforms.
