### PR TITLE
Add ability to split stage and publish artifact steps

### DIFF
--- a/azure-pipelines/artifacts/_all.ps1
+++ b/azure-pipelines/artifacts/_all.ps1
@@ -12,7 +12,7 @@
       Value = an array of paths (absolute or relative to the BaseDirectory) to files to include in the artifact.
               FileInfo objects are also allowed.
 .PARAMETER Force
-    Executes artifact scripts even if they have already been uploaded.
+    Executes artifact scripts even if they have already been staged.
 #>
 
 param (
@@ -28,14 +28,14 @@ Function EnsureTrailingSlash($path) {
     $path.Replace('\', [IO.Path]::DirectorySeparatorChar)
 }
 
-Function Test-ArtifactUploaded($artifactName) {
-    $varName = "ARTIFACTUPLOADED_$($artifactName.ToUpper())"
+Function Test-ArtifactStaged($artifactName) {
+    $varName = "ARTIFACTSTAGED_$($artifactName.ToUpper())"
     Test-Path "env:$varName"
 }
 
 Get-ChildItem "$PSScriptRoot\*.ps1" -Exclude "_*" -Recurse | % {
     $ArtifactName = $_.BaseName
-    if ($Force -or !(Test-ArtifactUploaded($ArtifactName + $ArtifactNameSuffix))) {
+    if ($Force -or !(Test-ArtifactStaged($ArtifactName + $ArtifactNameSuffix))) {
         $totalFileCount = 0
         $fileGroups = & $_
         if ($fileGroups) {
@@ -65,6 +65,6 @@ Get-ChildItem "$PSScriptRoot\*.ps1" -Exclude "_*" -Recurse | % {
             Write-Warning "No files found for the `"$ArtifactName`" artifact."
         }
     } else {
-        Write-Host "Skipping $ArtifactName because it has already been uploaded." -ForegroundColor DarkGray
+        Write-Host "Skipping $ArtifactName because it has already been staged." -ForegroundColor DarkGray
     }
 }

--- a/azure-pipelines/artifacts/_pipelines.ps1
+++ b/azure-pipelines/artifacts/_pipelines.ps1
@@ -2,14 +2,39 @@
 # into commands that instruct Azure Pipelines to actually collect those artifacts.
 
 param (
-    [string]$ArtifactNameSuffix
+    [string]$ArtifactNameSuffix,
+    [switch]$StageOnly
 )
 
-& "$PSScriptRoot/_stage_all.ps1" -ArtifactNameSuffix $ArtifactNameSuffix |% {
-    Write-Host "##vso[artifact.upload containerfolder=$($_.Name);artifactname=$($_.Name);]$($_.Path)"
+Function Set-PipelineVariable($name, $value) {
+    if ((Test-Path "Env:\$name") -and (Get-Item "Env:\$name").Value -eq $value) {
+        return # already set
+    }
 
+    #New-Item -Path "Env:\$name".ToUpper() -Value $value -Force | Out-Null
+    Write-Host "##vso[task.setvariable variable=$name]$value"
+}
+
+Function Test-ArtifactUploaded($artifactName) {
+    $varName = "ARTIFACTUPLOADED_$($artifactName.ToUpper())"
+    Test-Path "env:$varName"
+}
+
+& "$PSScriptRoot/_stage_all.ps1" -ArtifactNameSuffix $ArtifactNameSuffix |% {
     # Set a variable which will out-live this script so that a subsequent attempt to collect and upload artifacts
     # will skip this one from a check in the _all.ps1 script.
-    $varName = "ARTIFACTUPLOADED_$($_.Name.ToUpper())"
-    Write-Host "##vso[task.setvariable variable=$varName]true"
+    Set-PipelineVariable "ARTIFACTSTAGED_$($_.Name.ToUpper())" 'true'
+    Write-Host "Staged artifact $($_.Name) to $($_.Path)"
+
+    if (!$StageOnly) {
+        if (Test-ArtifactUploaded $_.Name) {
+            Write-Host "Skipping $($_.Name) because it has already been uploaded." -ForegroundColor DarkGray
+        } else {
+            Write-Host "##vso[artifact.upload containerfolder=$($_.Name);artifactname=$($_.Name);]$($_.Path)"
+
+            # Set a variable which will out-live this script so that a subsequent attempt to collect and upload artifacts
+            # will skip this one from a check in the _all.ps1 script.
+            Set-PipelineVariable "ARTIFACTUPLOADED_$($_.Name.ToUpper())" 'true'
+        }
+    }
 }

--- a/azure-pipelines/artifacts/_stage_all.ps1
+++ b/azure-pipelines/artifacts/_stage_all.ps1
@@ -42,7 +42,13 @@ $Artifacts |% {
     }
 }
 
-$Artifacts |% { "$($_.ArtifactName)$ArtifactNameSuffix" } | Get-Unique |% {
+$ArtifactNames = $Artifacts |% { "$($_.ArtifactName)$ArtifactNameSuffix" }
+$ArtifactNames += Get-ChildItem env:ARTIFACTSTAGED_* |% {
+    # Return from ALLCAPS to the actual capitalization used for the artifact.
+    $artifactNameAllCaps = "$($_.Name.Substring('ARTIFACTSTAGED_'.Length))"
+    (Get-ChildItem $ArtifactStagingFolder\$artifactNameAllCaps* -Filter $artifactNameAllCaps).Name
+}
+$ArtifactNames | Get-Unique |% {
     $artifact = New-Object -TypeName PSObject
     Add-Member -InputObject $artifact -MemberType NoteProperty -Name Name -Value $_
     Add-Member -InputObject $artifact -MemberType NoteProperty -Name Path -Value (Join-Path $ArtifactStagingFolder $_)


### PR DESCRIPTION
Now if a repo needs to post-process the staged artifacts before they are published, it need only add these lines to the pipeline to do just the stage:

```yaml
- powershell: azure-pipelines/artifacts/_pipelines.ps1 -ArtifactNameSuffix "-$(Agent.JobName)" -StageOnly
  failOnStderr: true
  displayName: Stage artifacts
  condition: succeededOrFailed()
```

Note the `-StageOnly` switch. 
The subsequent task without that switch will skip staging artifacts that were already staged, and proceed with publish.