### PR TITLE
Include only unique coverage reports in artifact

### DIFF
--- a/azure-pipelines/artifacts/coverageResults.ps1
+++ b/azure-pipelines/artifacts/coverageResults.ps1
@@ -1,6 +1,6 @@
 $RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
 
-$coverageFiles = @(Get-ChildItem "$RepoRoot/test/*.cobertura.xml" -Recurse)
+$coverageFiles = @(Get-ChildItem "$RepoRoot/test/*.cobertura.xml" -Recurse | Where {$_.FullName -notlike "*/In/*"  -and $_.FullName -notlike "*\In\*" })
 
 # Prepare code coverage reports for merging on another machine
 if ($env:SYSTEM_DEFAULTWORKINGDIRECTORY) {


### PR DESCRIPTION
The test runner is creating *two* cobertura.xml files for each test run. Besides doubling the size of the coverageResults artifact, this makes the `publish-codecoverage.yml` pipeline step do much more work which can take *minutes* instead of seconds.