### PR TITLE
CodeCov binary uploader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,8 @@ jobs:
         path: ${{ runner.temp }}/_artifacts/deployables
       if: always()
     - name: Publish code coverage results to codecov.io
-      run: bash <(curl -s https://codecov.io/bash)
-      shell: bash
+      run: ./azure-pipelines/publish-CodeCov.ps1 -CodeCovToken "${{ env.codecov_token }}" -PathToCodeCoverage "${{ runner.temp }}/_artifacts/coverageResults" -Name "${{ runner.os }} Coverage Results" -Flags "${{ runner.os }}Host,${{ env.BUILDCONFIGURATION }}"
+      shell: pwsh
       timeout-minutes: 3
       continue-on-error: true
+      if: always()

--- a/azure-pipelines/Get-CodeCovTool.ps1
+++ b/azure-pipelines/Get-CodeCovTool.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+    Downloads the CodeCov.io uploader tool and returns the path to it.
+#>
+[CmdletBinding()]
+Param(
+)
+
+$toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"
+$binaryToolsPath = Join-Path $toolsPath codecov
+if (!(Test-Path $binaryToolsPath)) { $null = mkdir $binaryToolsPath }
+
+if ($IsMacOS)
+{
+    $codeCovPath = Join-Path $binaryToolsPath codecov
+    $codeCovUrl = "https://uploader.codecov.io/latest/macos/codecov"
+}
+elseif ($IsLinux)
+{
+    $codeCovPath = Join-Path $binaryToolsPath codecov
+    $codeCovUrl = "https://uploader.codecov.io/latest/linux/codecov"
+}
+else
+{
+    $codeCovPath = Join-Path $binaryToolsPath codecov.exe
+    $codeCovUrl = "https://uploader.codecov.io/latest/windows/codecov.exe"
+}
+
+if (!(Test-Path $codeCovPath)) {
+    Write-Host "Downloading latest codeconv..." -ForegroundColor Yellow
+    (New-Object System.Net.WebClient).DownloadFile($codeCovUrl, $codeCovPath)
+}
+
+if ($IsMacOS -or $IsLinux) {
+    chmod u+x $codeCovPath
+}
+
+return (Resolve-Path $codeCovPath).Path

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -16,7 +16,10 @@ steps:
   displayName: 📢 Publish artifacts
   condition: succeededOrFailed()
 
-- bash: bash <(curl -s https://codecov.io/bash)
+- powershell: |
+    $ArtifactStagingFolder = & "azure-pipelines/Get-ArtifactsStagingDirectory.ps1"
+    $CoverageResultsFolder = Join-Path $ArtifactStagingFolder "coverageResults-$(Agent.JobName)"
+    azure-pipelines/publish-CodeCov.ps1 -CodeCovToken "$(codecov_token)" -PathToCodeCoverage "$CoverageResultsFolder" -Name "$(Agent.JobName) Coverage Results" -Flags "$(Agent.JobName)Host,$(BuildConfiguration)"
   displayName: 📢 Publish code coverage results to codecov.io
   condition: ne(variables['codecov_token'], '')
   timeoutInMinutes: 3

--- a/azure-pipelines/publish-CodeCov.ps1
+++ b/azure-pipelines/publish-CodeCov.ps1
@@ -1,0 +1,42 @@
+<#
+.SYNOPSIS
+    Uploads code coverage to codecov.io
+.PARAMETER CodeCovToken
+    Code coverage token to use
+.PARAMETER PathToCodeCoverage
+    Path to root of code coverage files
+.PARAMETER Name
+    Optional name to upload with codecoverge
+.PARAMETER Flags
+    Optional flags to upload with codecoverge
+#>
+[CmdletBinding()]
+Param (
+    [string]$CodeCovToken,
+    [string]$PathToCodeCoverage,
+    [string]$Name="",
+    [string]$Flags=""
+)
+
+$RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
+$CodeCoveragePathWildcard = (Join-Path $PathToCodeCoverage "*.cobertura.xml")
+
+Write-Host "RepoRoot: $RepoRoot" -ForegroundColor Yellow
+Write-Host "CodeCoveragePathWildcard: $CodeCoveragePathWildcard" -ForegroundColor Yellow
+
+Get-ChildItem -Recurse -Path $CodeCoveragePathWildcard | % {
+
+    if ($IsMacOS -or $IsLinux)
+    {
+        $relativeFilePath = Resolve-Path -relative $_
+    }
+    else
+    {
+        $relativeFilePath = Resolve-Path -relative (Get-ChildItem $_ | Select-Object -ExpandProperty Target)
+    }
+
+    Write-Host "Uploading: $relativeFilePath" -ForegroundColor Yellow
+    Write-Host "Flags: $Flags$TargetFrameworkFlag$TestTypeFlag$OSTypeFlag" -ForegroundColor Yellow
+
+    & (& "$PSScriptRoot/Get-CodeCovTool.ps1") -t "$CodeCovToken" -f "$relativeFilePath" -R "$RepoRoot" -F "$Flags" -n "$Name"
+}


### PR DESCRIPTION
Replaces the bash CodeCov uploader with the latest binary version.  A PowerShell script downloads the latest codecov binary.  Another PowerShell script collects and uploads code coverage artifact files to CodeCov.io.  You can pass flags and a coverage report name as parameters.