### PR TITLE
Drop .NET Core 3.1 target

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.401-focal
+# Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
+FROM mcr.microsoft.com/dotnet/sdk:7.0.101-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,5 +4,10 @@
     <EmbedUntrackedSources Condition=" '$(UseWPF)' == 'true' ">false</EmbedUntrackedSources>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
+    <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
+  </ItemGroup>
+
   <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "7.0.101",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/src/Library/Library.csproj
+++ b/src/Library/Library.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Library.Tests/CalculatorTests.cs
+++ b/test/Library.Tests/CalculatorTests.cs
@@ -14,7 +14,7 @@ public class CalculatorTests
     public void AddOrSubtract()
     {
         // This tests aggregation of code coverage across test runs.
-#if NETCOREAPP3_1
+#if NET6_0_OR_GREATER
         Assert.Equal(3, Calculator.Add(1, 2));
 #else
         Assert.Equal(-1, Calculator.Subtract(1, 2));

--- a/test/Library.Tests/Library.Tests.csproj
+++ b/test/Library.Tests/Library.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <RootNamespace />
   </PropertyGroup>
 


### PR DESCRIPTION
[.NET Core 3.1 is dead](https://dotnet.microsoft.com/en-us/download/dotnet). Long live .NET 6 and 7.