### PR TITLE
Use latest NuGet.exe version

### DIFF
--- a/azure-pipelines/Get-NuGetTool.ps1
+++ b/azure-pipelines/Get-NuGetTool.ps1
@@ -6,7 +6,7 @@
 #>
 Param(
     [Parameter()]
-    [string]$NuGetVersion='5.2.0'
+    [string]$NuGetVersion='latest'
 )
 
 $toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"
@@ -16,7 +16,7 @@ $nugetPath = Join-Path $binaryToolsPath nuget.exe
 
 if (!(Test-Path $nugetPath)) {
     Write-Host "Downloading nuget.exe $NuGetVersion..." -ForegroundColor Yellow
-    (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v$NuGetVersion/NuGet.exe", $nugetPath)
+    (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/$NuGetVersion/NuGet.exe", $nugetPath)
 }
 
 return (Resolve-Path $nugetPath).Path

--- a/azure-pipelines/Get-NuGetTool.ps1
+++ b/azure-pipelines/Get-NuGetTool.ps1
@@ -6,7 +6,7 @@
 #>
 Param(
     [Parameter()]
-    [string]$NuGetVersion='latest'
+    [string]$NuGetVersion='6.4.0'
 )
 
 $toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"
@@ -16,7 +16,7 @@ $nugetPath = Join-Path $binaryToolsPath nuget.exe
 
 if (!(Test-Path $nugetPath)) {
     Write-Host "Downloading nuget.exe $NuGetVersion..." -ForegroundColor Yellow
-    (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/$NuGetVersion/NuGet.exe", $nugetPath)
+    (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v$NuGetVersion/NuGet.exe", $nugetPath)
 }
 
 return (Resolve-Path $nugetPath).Path


### PR DESCRIPTION
As per NuGet.org, the NuGet.exe version used currently has at least one vulnerability https://www.nuget.org/packages/NuGet.CommandLine/5.2.1. Hence proposing to use latest NuGet.exe version always. If the latest version has a regression, we can always pin to a particular version by passing `v{versionnumber}` as a parameter to the powershell script.