### PR TITLE
Skip NOTICE generation on PRs

### DIFF
--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -7,6 +7,7 @@ steps:
   inputs:
     outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
     outputformat: text
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
 - task: MicroBuildSigningPlugin@3
   inputs:


### PR DESCRIPTION
NOTICE generation fails frequently due to throttling, so this will both help keep PRs going, and reduce the demand on the network resource.