### PR TITLE
Drop test-tools as a nuget feed source

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -7,18 +7,9 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <!-- Defend against user or machine level disabling of sources that we list in this file. -->
     <clear />
   </disabledPackageSources>
-  <packageSourceMapping>
-    <packageSource key="test-tools">
-      <package pattern="Microsoft.CodeCoverage" />
-    </packageSource>
-    <packageSource key="nuget">
-      <package pattern="*" />
-    </packageSource>
-  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
We don't need it now that we're using stable Microsoft.CodeCoverage package versions.
