### PR TITLE
Remove `dotnet-format` as a tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,12 +8,6 @@
         "pwsh"
       ]
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "dotnet-coverage": {
       "version": "17.9.3",
       "commands": [

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,3 @@ updates:
   directory: /
   schedule:
     interval: weekly
-  ignore:
-  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
-  - dependency-name: dotnet-format
-    versions: ["6.x", "7.x", "8.x", "9.x"]


### PR DESCRIPTION
It's part of the SDK now, and the version on nuget.org is no longer maintained.