### PR TITLE
Always include apiscan logs

### DIFF
--- a/azure-pipelines/apiscan.yml
+++ b/azure-pipelines/apiscan.yml
@@ -14,6 +14,7 @@ jobs:
       displayName: 📢 collect apiscan artifact
       targetPath: $(Pipeline.Workspace)/.gdn/.r/apiscan/001/Logs
       artifactName: apiscan-logs
+      condition: succeededOrFailed()
   variables:
   - name: SymbolsFeatureName
     value: $[ dependencies.Windows.outputs['SetPipelineVariables.SymbolsFeatureName'] ]


### PR DESCRIPTION
This will make it so that API Scan logs are not dropped when any of the API Scan checks fail.
Some of these failures need the logs in order to be troubleshooted.