### PR TITLE
Merge test related dependency updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0" />
-    <PackageVersion Include="xunit" Version="2.8.0" />
+    <PackageVersion Include="xunit" Version="2.8.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />


### PR DESCRIPTION
- Bump xunit from 2.8.0 to 2.8.1
- Bump Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0
- Bump xunit.runner.visualstudio from 2.8.0 to 2.8.1
