### PR TITLE
Ensure Expand-Template uses UTF-8 when replacing placeholders.

### DIFF
--- a/Expand-Template.ps1
+++ b/Expand-Template.ps1
@@ -36,7 +36,7 @@ function Replace-Placeholders {
 
     $Path = Resolve-Path $Path
     Write-Host "Replacing tokens in `"$Path`""
-    $content = Get-Content -Path $Path | Out-String
+    $content = Get-Content -Encoding UTF8 -Path $Path | Out-String
     $Replacements.GetEnumerator() |% {
         $modifiedContent = $content -replace $_.Key,$_.Value
         if ($modifiedContent -eq $content) {


### PR DESCRIPTION
Windows PowerShell 5.1 uses Default encoding for Get-Content instead of UTF-8 which incorrectly reads the encoding of some yaml files and breaks their emojis (like 📢) when running expand-template.ps1.