### PR TITLE
Avoid running tests on mono for test project

### DIFF
--- a/test/Library.Tests/Library.Tests.csproj
+++ b/test/Library.Tests/Library.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace />
   </PropertyGroup>
 


### PR DESCRIPTION
The mono runtime is obsolete for most applications.