### PR TITLE
Revert "Merge pull request #319 from AArnott/betterTestingLibTemplate"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -7,7 +7,4 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" IncludeAssets="runtime" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This reverts commit 01eeb1aff44be490aea525baa92f89240ba2f682, reversing changes made to 0a42cd9afd1e40f6a5392850a5115ca5f42dfd9a.

See https://github.com/Tyrrrz/GitHubActionsTestLogger/discussions/37 for an ongoing discussion. The short explanation is that this new logger is simply too likely to break things. It was hard enough to get it to work in the template repo itself, but the very first "real" repo I merged the change into broke with a crash in the test runner on Windows.