### PR TITLE
Fix test logs collection

### DIFF
--- a/.github/actions/publish-artifacts/action.yaml
+++ b/.github/actions/publish-artifacts/action.yaml
@@ -32,13 +32,6 @@ runs:
       name: build_logs-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/build_logs
     continue-on-error: true
-  - name: 📢 Upload test_logs
-    if: always()
-    uses: actions/upload-artifact@v4
-    with:
-      name: test_logs-${{ runner.os }}
-      path: ${{ runner.temp }}/_artifacts/test_logs
-    continue-on-error: true
   - name: 📢 Upload testResults
     if: always()
     uses: actions/upload-artifact@v4

--- a/tools/artifacts/testResults.ps1
+++ b/tools/artifacts/testResults.ps1
@@ -7,7 +7,8 @@ $result = @{}
 $testRoot = Resolve-Path "$PSScriptRoot\..\..\test"
 $result[$testRoot] = (Get-ChildItem "$testRoot\TestResults" -Recurse -Directory | Get-ChildItem -Recurse -File)
 
-$testlogsPath = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY\test_logs"
+$artifactStaging = & "$PSScriptRoot\..\Get-ArtifactsStagingDirectory.ps1"
+$testlogsPath = Join-Path $artifactStaging "test_logs"
 if (Test-Path $testlogsPath) {
     $result[$testlogsPath] = Get-ChildItem "$testlogsPath\*";
 }


### PR DESCRIPTION
They are intended to be collected as part of the `testResults` artifact.