### PR TITLE
Separate official and unofficial pipelines

### DIFF
--- a/Expand-Template.ps1
+++ b/Expand-Template.ps1
@@ -156,7 +156,7 @@ try {
     $YmlReplacements = @{
         "(?m)^\s+- microbuild`r?`n"=""
     }
-    Replace-Placeholders -Path "azure-pipelines\official.yml" -Replacements $YmlReplacements
+    Replace-Placeholders -Path "azure-pipelines\unofficial.yml" -Replacements $YmlReplacements
     Replace-Placeholders -Path "azure-pipelines.yml" -Replacements $YmlReplacements
 
     $YmlReplacements = @{}

--- a/azure-pipelines/apiscan.yml
+++ b/azure-pipelines/apiscan.yml
@@ -1,6 +1,8 @@
 parameters:
 - name: windowsPool
   type: object
+- name: RealSign
+  type: boolean
 
 jobs:
 - job: apiscan
@@ -9,6 +11,12 @@ jobs:
   pool: ${{ parameters.windowsPool }}
   timeoutInMinutes: 120
   templateContext:
+    ${{ if not(parameters.RealSign) }}:
+      mb:
+        signing: # if the build is test-signed, install the signing plugin so that CSVTestSignPolicy.xml is available
+          enabled: true
+          zipSources: false
+          signType: test
     outputs:
     - output: pipelineArtifact
       displayName: 📢 collect apiscan artifact

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -313,3 +313,4 @@ jobs:
     - template: apiscan.yml
       parameters:
         windowsPool: ${{ parameters.windowsPool }}
+        RealSign: ${{ parameters.RealSign }}

--- a/azure-pipelines/unofficial.yml
+++ b/azure-pipelines/unofficial.yml
@@ -1,11 +1,17 @@
-trigger: none # We only want to trigger manually or based on a schedule
-pr: none
-#schedules:
-#- cron: "0 3 * * *" # Daily @ 8 PM PST
-#  displayName: Daily vs-insertion
-#  branches:
-#    include:
-#    - microbuild
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - microbuild
+    - 'validate/*'
+  paths:
+    exclude:
+    - doc/
+    - '*.md'
+    - .vscode/
+    - azure-pipelines/release.yml
+    - azure-pipelines/vs-insertion.yml
 
 parameters:
 # As an entrypoint pipeline yml file, all parameters here show up in the Queue Run dialog.
@@ -26,7 +32,11 @@ parameters:
 - name: EnableAPIScan
   displayName: Include APIScan with compliance tools
   type: boolean
-  default: false # enable in individual repos only AFTER updating TSAOptions.json with your own values
+  default: false
+- name: EnableProductionSDL
+  displayName: Enable Production SDL
+  type: boolean
+  default: false
 
 resources:
   repositories:
@@ -39,21 +49,22 @@ variables:
 - template: GlobalVariables.yml
 
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     sdl:
       sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
-      codeSignValidation:
-        enabled: true
-        break: true
-        additionalTargetsGlobPattern: -|Variables-*\*.ps1;-|APIScanInputs-*\**;-|test_symbols-*\**;-|MicroBuild\**
-      policheck:
-        enabled: true
-        exclusionsFile: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
       suppression:
         suppressionFile: $(System.DefaultWorkingDirectory)\azure-pipelines\falsepositives.gdnsuppress
+      enableProductionSDL: ${{ parameters.EnableProductionSDL }}
+      codeSignValidation:
+        enabled: ${{ parameters.EnableProductionSDL }}
+        break: true
+        policyFile: $(MBSIGN_APPFOLDER)\CSVTestSignPolicy.xml
+      policheck:
+        enabled: ${{ parameters.EnableProductionSDL }}
+        exclusionsFile: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
       sbom:
-        enabled: true
+        enabled: ${{ parameters.EnableProductionSDL }}
     stages:
     - stage: Build
       variables:
@@ -62,7 +73,7 @@ extends:
       - template: /azure-pipelines/build.yml@self
         parameters:
           Is1ESPT: true
-          RealSign: true
+          RealSign: false
           # ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
           EnableAPIScan: ${{ parameters.EnableAPIScan }}
           windowsPool: VSEngSS-MicroBuild2022-1ES
@@ -77,6 +88,3 @@ extends:
             os: macOS
           EnableMacOSBuild: ${{ parameters.EnableMacOSBuild }}
           RunTests: ${{ parameters.RunTests }}
-    - template: /azure-pipelines/prepare-insertion-stages.yml@self
-      parameters:
-        RealSign: true

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -87,7 +87,7 @@ extends:
             packageParentPath: $(Pipeline.Workspace)/VSInsertion-Windows
             allowPackageConflicts: true
             publishVstsFeed: VS
-        - task: MicroBuildInsertVsPayload@4
+        - task: MicroBuildInsertVsPayload@5
           displayName: 🏭 Insert VS Payload
           inputs:
             TeamName: $(TeamName)
@@ -96,7 +96,7 @@ extends:
             InsertionDescription: |
               This PR is for **validation purposes only** for !$(System.PullRequest.PullRequestId). **Do not complete**.
             CustomScriptExecutionCommand: src/VSSDK/NuGet/AllowUnstablePackages.ps1
-            InsertionBuildPolicy: Request Perf DDRITs
+            InsertionBuildPolicies: Request Perf DDRITs
             InsertionReviewers: $(Build.RequestedFor)
             DraftPR: false # set to true and update InsertionBuildPolicy when we can specify all the validations we want to run (https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2224288)
             AutoCompletePR: false


### PR DESCRIPTION
Separate official and unofficial pipelines.
This is to satisfy the requirement that pipelines marked as production never use the unofficial templates.