### PR TITLE
Revert "Opt in to the new MicroBuild SBOM behavior"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,6 +61,4 @@
       <PackageReleaseNotes Condition="'$(RepositoryUrl)'!=''">$(RepositoryUrl)/releases/tag/v$(Version)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
-
-  <Import Project="azure-pipelines\NuGetSbom.props" />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,4 +4,6 @@
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
   </ItemGroup>
+
+  <Import Project="azure-pipelines\NuGetSbom.targets" Condition="'$(IsPackable)'!='false'" />
 </Project>

--- a/azure-pipelines/NuGetSbom.props
+++ b/azure-pipelines/NuGetSbom.props
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <GenerateSBOMThisProject>true</GenerateSBOMThisProject>
-    <UseMicroBuildSbomPluginVersion>2</UseMicroBuildSbomPluginVersion>
-  </PropertyGroup>
-</Project>

--- a/azure-pipelines/NuGetSbom.targets
+++ b/azure-pipelines/NuGetSbom.targets
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <GenerateSBOMThisProject>true</GenerateSBOMThisProject>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeSbomInNupkg</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="IncludeSbomInNupkg">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(SbomOutput)" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Reverts AArnott/Library.Template#362

The new SBOM v2 plugin breaks on `dotnet build` due to its use of the `Unzip` task, which inside a project with the VSSDK.BuildTools is overridden to one that targets .NET and is incompatible with .NET Framework.