### PR TITLE
Enable PME signing for Library.Template

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -118,6 +118,7 @@ jobs:
           zipSources: false
           ${{ if parameters.RealSign }}:
             signType: real
+            signWithProd: true
           ${{ else }}:
             signType: test
         sbom:
@@ -223,6 +224,7 @@ jobs:
               signing:
                 enabled: false # enable when building unique artifacts on this agent that must be signed
                 signType: real
+                signWithProd: true
           outputParentDirectory: $(Build.ArtifactStagingDirectory)
           outputs:
           - ${{ each artifact_name in parameters.artifact_names }}:
@@ -258,6 +260,7 @@ jobs:
               signing:
                 enabled: false # enable when building unique artifacts on this agent that must be signed
                 signType: real
+                signWithProd: true
           outputParentDirectory: $(Build.ArtifactStagingDirectory)
           outputs:
           - ${{ each artifact_name in parameters.artifact_names }}:

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -44,6 +44,7 @@ steps:
     inputs:
       signType: Real
       zipSources: false
+      ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea # devdiv's SC ID
     displayName: 🔧 Install MicroBuild Signing Plugin
 
   - ${{ if parameters.EnableLocalization }}:


### PR DESCRIPTION
## What/Why
We need to enable PME signing with the new rule enforcement (Real signing with PME Enforcement - June 30th 2025). 

## How
Enable PME signing with `signWithProd: true`.

- I updated `microbuild.before.yml` that doesn't use the MicroBuild template to add the `ConnectedPMEServiceName` as suggested in the wiki, but please let me know if this yml is not used at all now; I can revert my change.

- I updated three places in `build.yml` including two of the places where signing was `enabled: false`, in case someone enables it to build unique artifacts on the agent.

## Testing

I'll need some help on this since I can't test run the pipeline, but we'll need to verify if the pipeline stages are correctly set up like this example:

![image](https://github.com/user-attachments/assets/a139e928-2860-472e-8f4b-e385882f7b91)

Can't actually run the pipeline, since the requirement now is that only SAW machines will be able to manually queue a real-signed production build.