### PR TITLE
Pass through System.AccessToken when real signing on non-Windows builds

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -246,6 +246,7 @@ jobs:
         parameters:
           Is1ESPT: ${{ parameters.Is1ESPT }}
           RunTests: ${{ parameters.RunTests }}
+          BuildRequiresAccessToken: ${{ parameters.RealSign }} # Real signing on non-Windows machines requires passing through access token to build steps that sign
       - ${{ if parameters.EnableDotNetFormatCheck }}:
         - script: dotnet format --verify-no-changes
           displayName: 💅 Verify formatted code
@@ -282,6 +283,7 @@ jobs:
         parameters:
           Is1ESPT: ${{ parameters.Is1ESPT }}
           RunTests: ${{ parameters.RunTests }}
+          BuildRequiresAccessToken: ${{ parameters.RealSign }} # Real signing on non-Windows machines requires passing through access token to build steps that sign
       - template: expand-template.yml
 
   - job: WrapUp

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -5,11 +5,17 @@ parameters:
   default: false
 - name: Is1ESPT
   type: boolean
+- name: BuildRequiresAccessToken
+  type: boolean
+  default: false
 
 steps:
 
 - script: dotnet build -t:build,pack --no-restore -c $(BuildConfiguration) -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904,LOCTASK002 /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
   displayName: 🛠 dotnet build
+  ${{ if parameters.BuildRequiresAccessToken }}:
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 - ${{ if not(parameters.IsOptProf) }}:
   - powershell: tools/dotnet-test-cloud.ps1 -Configuration $(BuildConfiguration) -Agent $(Agent.JobName) -PublishResults


### PR DESCRIPTION
# What
Pass through `System.AccessToken` when real signing on non-Windows builds

# Why
Production signing on non-Windows machines requires the `System.AccessToken` to properly acquire the token needed to sign files.

# How
- Add a new parameter to `dotnet.yml` to pass the `System.AccessToken` through the environment variables of the `dotnet` script
- Pass through the parameter to set `System.AccessToken` for Linux and MacOS builds when real signing

# Validation
- Verified a Linux build can now real sign
