### PR TITLE
Migrate from managed identity to service connection for APIScan.

### DIFF
--- a/azure-pipelines/apiscan.yml
+++ b/azure-pipelines/apiscan.yml
@@ -28,9 +28,6 @@ jobs:
     value: $[ dependencies.Windows.outputs['SetPipelineVariables.SymbolsFeatureName'] ]
   - name: NBGV_MajorMinorVersion
     value: $[ dependencies.Windows.outputs['nbgv.NBGV_MajorMinorVersion'] ]
-  - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
-    # https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/25351/APIScan-step-by-step-guide-to-setting-up-a-Pipeline
-    - group: VSEng sponsored APIScan # Expected to provide ApiScanClientId
   steps:
     # We need TSAOptions.json
   - checkout: self
@@ -49,8 +46,7 @@ jobs:
       isLargeApp: false
       toolVersion: Latest
       preserveLogsFolder: true
-    env:
-      AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
+      azureSubscription: 'VSEng-APIScanSC'
 
   # File bugs when APIScan finds issues
   - task: TSAUpload@2


### PR DESCRIPTION
- Remove the APIScan variable group because it will not be needed anymore
- Add the azureSubscription service connection input and point to the vseng centralized apiscan service connection.
- 