### PR TITLE
Split the VS PR stage separately from the upload steps

### DIFF
--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -27,9 +27,9 @@ extends:
       sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
 
     stages:
-    - stage: upload_payload
+    - stage: insertion
       jobs:
-      - job: upload_payload
+      - job: upload
         displayName: Upload VS payload
         pool: VSEngSS-MicroBuild2022-1ES
         templateContext:
@@ -57,23 +57,15 @@ extends:
             allowPackageConflicts: true
             publishVstsFeed: VS
 
-    - stage: insertion
-      dependsOn: upload_payload
-      condition: succeeded('upload_payload')
-      jobs:
-      - job: insertion
+      - job: insert
+        dependsOn: upload
         displayName: VS insertion
         pool: VSEngSS-MicroBuild2022-1ES
         templateContext:
           outputParentDirectory: $(Pipeline.Workspace)/CI
         steps:
         - checkout: none
-        - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
-          displayName: ⚙️ Set pipeline name
         - template: azure-pipelines/release-deployment-prep.yml@self
-        - download: CI
-          artifact: VSInsertion-Windows
-          displayName: 🔻 Download VSInsertion-Windows artifact
         - task: MicroBuildInsertVsPayload@5
           displayName: 🏭 Insert VS Payload
           inputs:

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -63,10 +63,10 @@ extends:
         ArchiveSymbols: false
         RealSign: false
 
-    - stage: upload_payload
-      displayName: Upload VS payload
+    - stage: insertion
+      displayName: VS insertion
       jobs:
-      - job: upload_payload
+      - job: upload
         displayName: Upload VS payload
         pool: VSEngSS-MicroBuild2022-1ES
         steps:
@@ -96,13 +96,9 @@ extends:
             allowPackageConflicts: true
             publishVstsFeed: VS
 
-    - stage: insertion
-      displayName: VS insertion
-      dependsOn: upload_payload
-      condition: succeeded('upload_payload')
-      jobs:
       - job: insertion
         displayName: VS insertion
+        dependsOn: upload
         pool: VSEngSS-MicroBuild2022-1ES
         steps:
         - checkout: self
@@ -113,9 +109,6 @@ extends:
           displayName: 🔻 Download Variables-Windows artifact
         - powershell: $(Pipeline.Workspace)/Variables-Windows/_define.ps1
           displayName: ⚙️ Set pipeline variables based on artifacts
-        - download: current
-          artifact: VSInsertion-Windows
-          displayName: 🔻 Download VSInsertion-Windows artifact
         - task: MicroBuildInsertVsPayload@5
           displayName: 🏭 Insert VS Payload
           inputs:


### PR DESCRIPTION
There is sometimes an issue with the clone/create PR step. When that happens, the stage isn't requeuable because the VSTS upload step fails when its run again because the payload is already there. This update allows the step to clone the VS repo and create the PR to be rerun due to issues independent of the Upload step.