### PR TITLE
Update variables to handle InsertJsonValues too long

### DIFF
--- a/tools/variables/_all.ps1
+++ b/tools/variables/_all.ps1
@@ -14,33 +14,7 @@ $vars = @{}
 
 Get-ChildItem "$PSScriptRoot\*.ps1" -Exclude "_*" | % {
     Write-Host "Computing $($_.BaseName) variable"
-    # AzDO variables are stored as environment variables which has a max length of ~32k characters.
-    if ($_.Length -gt 32000) {
-        # If the InsertJsonValues script returns a value longer than that,
-        # write the value to a temp file and use the InsertJsonValuesFile variable that InsertVSPayload understands.
-        if ($_.BaseName -eq "InsertJsonValues") {
-            Write-Warning "The script InsertJsonValues.ps1 is longer than 32k characters."
-            Write-Warning "Writing to a temp file and setting INSERTJSONVALUESFILE to the location of the file."
-
-            $tempDir = "$env:AGENT_TEMPDIRECTORY"
-            if (-not $tempDir) {
-                Write-Warning "AGENT_TEMPDIRECTORY environment variable is not set. Defaulting to %TMP% which is set to '$env:TMP'."
-                $tempDir = $env:TMP
-            }
-
-            $tmpFile = Join-Path "$tempDir" ("InsertJsonValuesFile_{0}.txt" -f ([guid]::NewGuid()))
-            Write-Host "Writing contents of InsertJsonValues to file: $tmpFile."
-            $contents = & $_
-            Set-Content -Path $tmpFile -Value $contents
-	    
-            # Write file to the new parameter.
-            $vars["InsertJsonValuesFile"] = "$tmpFile"
-        } else {
-            Write-Error "The script $($_.BaseName).ps1 is too long (> 32k characters). Skipping setting the environment variable."
-        }
-    } else {
-        $vars[$_.BaseName] = & $_
-    }
+    $vars[$_.BaseName] = & $_
 }
 
 $vars

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -19,7 +19,35 @@ param (
     } else {
         Write-Host "$keyCaps=$($_.Value)" -ForegroundColor Yellow
 
-        if ($($_.Value).Length -gt 32000) {
+        # AzDO variables are stored as environment variables which has a max length of ~32k characters.
+        if ($_.Key -eq "InsertJsonValues" -and $($_.Value).Length -gt 32000) {
+            # If the InsertJsonValues value is longer than that,
+            # write the value to a temp file and use the InsertJsonValuesFile variable that InsertVSPayload understands.
+            Write-Warning "The value of InsertJsonValues is longer than 32k characters."
+            Write-Warning "Writing to a temp file and setting INSERTJSONVALUESFILE to the location of the file."
+
+            $tempDir = "$env:AGENT_TEMPDIRECTORY"
+            if (-not $tempDir) {
+                Write-Warning "AGENT_TEMPDIRECTORY environment variable is not set. Defaulting to %TMP% which is set to '$env:TMP'."
+                $tempDir = $env:TMP
+            }
+
+            $tmpFile = Join-Path "$tempDir" ("InsertJsonValuesFile_{0}.txt" -f ([guid]::NewGuid()))
+            Write-Host "Writing contents of InsertJsonValues to file: $tmpFile."
+            Set-Content -Path $tmpFile -Value $($_.Value)
+
+            # Set the InsertJsonValuesFile variable to the temp file path.
+            $insertJsonValuesFileKeyCaps = "INSERTJSONVALUESFILE"
+            Write-Host "$insertJsonValuesFileKeyCaps=$tmpFile" -ForegroundColor Yellow
+            if ($env:TF_BUILD) {
+                Write-Host "##vso[task.setvariable variable=$insertJsonValuesFileKeyCaps]$tmpFile"
+                Write-Host "##vso[task.setvariable variable=$insertJsonValuesFileKeyCaps;isOutput=true]$tmpFile"
+            } elseif ($env:GITHUB_ACTIONS) {
+                Add-Content -LiteralPath $env:GITHUB_ENV -Value "$insertJsonValuesFileKeyCaps=$tmpFile"
+            }
+
+            Set-Item -LiteralPath "env:$insertJsonValuesFileKeyCaps" -Value $tmpFile
+        } elseif ($($_.Value).Length -gt 32000) {
             Write-Warning "The value is too long (> 32k characters). Skipping setting the environment variables."
         } else {
             if ($env:TF_BUILD) {


### PR DESCRIPTION
InsertJsonValues can be too long if there are many vsman to insert. If this happens, AzDO has a variable limitation of ~32k characters for the variable. This adds a check to use the newly introduced InsertJsonValuesFile where the InsertJsonValues is written to a file and then processed by InsertVSPayload.