### PR TITLE
Increase retry count on NOTICE task failure to 10

### DIFF
--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -23,7 +23,7 @@ steps:
     inputs:
       outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
       outputformat: text
-    retryCountOnTaskFailure: 3 # fails when the cloud service is overloaded
+    retryCountOnTaskFailure: 10 # fails when the cloud service is overloaded
     continueOnError: ${{ not(parameters.RealSign) }} # Tolerate failures when we're not building something that may ship.
 
 - ${{ if parameters.IsOptProf }}:


### PR DESCRIPTION
We have seen this task fail as many as 9 times in a row. It has various issues and has recently been handed to a new team. Hopefully reliability will improve, but for now, it may be helpful to increase retries more broadly.