### PR TITLE
Add the VSDrop service connection to the insert vs payload

### DIFF
--- a/azure-pipelines/OptProf.yml
+++ b/azure-pipelines/OptProf.yml
@@ -97,6 +97,10 @@ stages:
         TeamEmail: $(TeamEmail)
         SkipCreatePR: true
         CustomScriptExecutionCommand: src\VSSDK\NuGet\AllowUnstablePackages.ps1
+        ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
+          ConnectedVSDropServiceName: 'VSEng-VSDrop-MI'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
       displayName: Trigger a new build of DD-CB-TestSignVS-devCI
       inputs:

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -69,6 +69,11 @@ extends:
             AutoCompletePR: true
             AutoCompleteMergeStrategy: Squash
             ShallowClone: true
+            ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
+              ConnectedVSDropServiceName: 'VSEng-VSDrop-MI'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
         - powershell: |
             $contentType = 'application/json';
             $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -111,6 +111,10 @@ extends:
             DraftPR: false # set to true and update InsertionBuildPolicy when we can specify all the validations we want to run (https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2224288)
             AutoCompletePR: false
             ShallowClone: true
+            ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
+              ConnectedVSDropServiceName: 'VSEng-VSDrop-MI'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         - powershell: |
             $insertionPRId = azure-pipelines/Get-InsertionPRId.ps1
             $Markdown = @"


### PR DESCRIPTION
In some cases where the version number is not provided, the insert vs payload task will dynamically download the manifest files to determine the version number to use. In these cases, the insert vs payload task will need to use the vsdrop service connection.

Adding in the use of the service connection whether it is needed or not.