### PR TITLE
Throw on Download-NuGetPackage errors

### DIFF
--- a/tools/Download-NuGetPackage.ps1
+++ b/tools/Download-NuGetPackage.ps1
@@ -73,5 +73,5 @@ if ($Version) {
 if ($packageDir -and (Test-Path $packageDir)) {
     Write-Output $packageDir
 } else {
-    Write-Error "Package directory not found after download."
+    throw "Package directory not found after download. PackageId='$PackageId'; Version='$Version'; OutputDirectory='$OutputDirectory'; PackageRoot='$packageRoot'."
 }


### PR DESCRIPTION
Instead of writing an error and returning `$null` to the caller, we should do something that's harder to ignore.
