### PR TITLE
Fix several issues and make some enhancements to new PDB/package related tooling

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -36,6 +36,13 @@
         "repo"
       ],
       "rollForward": false
+    },
+    "dotnet-symbol": {
+      "version": "10.0.721401",
+      "commands": [
+        "dotnet-symbol"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.201@sha256:127d7d4d601ae26b8e04c54efb37e9ce8766931bded0ee59fcd799afd21d6850
+FROM mcr.microsoft.com/dotnet/sdk:10.0.202@sha256:adc02be8b87957d07208a4a3e51775935b33bad3317de8c45b1e67357b4c073b
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.202",
     "rollForward": "patch",
     "allowPrerelease": false
   },

--- a/init.ps1
+++ b/init.ps1
@@ -126,40 +126,40 @@ try {
         }
     }
 
-    $DownloadNuGetPkgScriptPath = "$PSScriptRoot\tools\Download-NuGetPackage.ps1"
+    $InstallNuGetPkgScriptPath = "$PSScriptRoot\tools\Install-NuGetPackage.ps1"
     $nugetVerbosity = 'quiet'
     if ($Verbose) { $nugetVerbosity = 'normal' }
     $MicroBuildPackageSource = 'https://pkgs.dev.azure.com/devdiv/_packaging/MicroBuildToolset%40Local/nuget/v3/index.json'
     if ($Signing) {
         Write-Host "Installing MicroBuild signing plugin" -ForegroundColor $HeaderColor
-        & $DownloadNuGetPkgScriptPath -PackageId MicroBuild.Plugins.Signing -Source $MicroBuildPackageSource -Verbosity $nugetVerbosity
+        & $InstallNuGetPkgScriptPath MicroBuild.Plugins.Signing -source $MicroBuildPackageSource -Verbosity $nugetVerbosity
         $EnvVars['SignType'] = "Test"
     }
 
     if ($Setup) {
         Write-Host "Installing MicroBuild SwixBuild plugin..." -ForegroundColor $HeaderColor
-        & $DownloadNuGetPkgScriptPath -PackageId Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild -Source $MicroBuildPackageSource -Verbosity $nugetVerbosity
+        & $InstallNuGetPkgScriptPath Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild -source $MicroBuildPackageSource -Verbosity $nugetVerbosity
     }
 
     if ($OptProf) {
         Write-Host "Installing MicroBuild OptProf plugin" -ForegroundColor $HeaderColor
-        & $DownloadNuGetPkgScriptPath -PackageId MicroBuild.Plugins.OptProf -Source $MicroBuildPackageSource -Verbosity $nugetVerbosity
+        & $InstallNuGetPkgScriptPath MicroBuild.Plugins.OptProf -source $MicroBuildPackageSource -Verbosity $nugetVerbosity
         $EnvVars['OptProfEnabled'] = '1'
     }
 
     if ($Localization) {
         Write-Host "Installing MicroBuild localization plugin" -ForegroundColor $HeaderColor
-        & $DownloadNuGetPkgScriptPath -PackageId MicroBuild.Plugins.Localization -Source $MicroBuildPackageSource -Verbosity $nugetVerbosity
+        & $InstallNuGetPkgScriptPath MicroBuild.Plugins.Localization -source $MicroBuildPackageSource -Verbosity $nugetVerbosity
         $EnvVars['LocType'] = "Pseudo"
         $EnvVars['LocLanguages'] = "JPN"
     }
 
     if ($SBOM) {
         Write-Host "Installing MicroBuild SBOM plugin" -ForegroundColor $HeaderColor
-        & $DownloadNuGetPkgScriptPath -PackageId MicroBuild.Plugins.Sbom -Source $MicroBuildPackageSource -Verbosity $nugetVerbosity
+        & $InstallNuGetPkgScriptPath MicroBuild.Plugins.Sbom -source $MicroBuildPackageSource -Verbosity $nugetVerbosity
         # The feed with the latest versions of the tool is at 'https://1essharedassets.pkgs.visualstudio.com/1esPkgs/_packaging/SBOMTool/nuget/v3/index.json',
         # but we'll use the feed that the SBOM task itself uses to install the tool for consistency.
-        $PkgMicrosoft_ManifestTool_CrossPlatform = & $DownloadNuGetPkgScriptPath -PackageId Microsoft.ManifestTool.CrossPlatform -Source $MicroBuildPackageSource -Verbosity $nugetVerbosity
+        $PkgMicrosoft_ManifestTool_CrossPlatform = & $InstallNuGetPkgScriptPath Microsoft.ManifestTool.CrossPlatform -source $MicroBuildPackageSource -Verbosity $nugetVerbosity
         $EnvVars['GenerateSBOM'] = "true"
         $EnvVars['PkgMicrosoft_ManifestTool_CrossPlatform'] = $PkgMicrosoft_ManifestTool_CrossPlatform
     }

--- a/tools/Convert-PDB.ps1
+++ b/tools/Convert-PDB.ps1
@@ -23,28 +23,25 @@ if ($IsMacOS -or $IsLinux) {
     return
 }
 
-$version = '1.1.0-beta2-21101-01'
-$baseDir = "$PSScriptRoot/../obj/tools"
-$pdb2pdbpath = "$baseDir/microsoft.diasymreader.pdb2pdb/$version/tools/Pdb2Pdb.exe"
-if (-not (Test-Path $pdb2pdbpath)) {
-    if (-not (Test-Path $baseDir)) { New-Item -Type Directory -Path $baseDir | Out-Null }
-    $baseDir = (Resolve-Path $baseDir).Path # Normalize it
-    # This package originally comes from the https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json feed.
-    # Add this feed as an upstream to whatever feed is in nuget.config if this step fails.
-    try {
-        & "$PSScriptRoot/Download-NuGetPackage.ps1" -PackageId Microsoft.DiaSymReader.Pdb2Pdb -Version $version -Source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json -OutputDirectory $baseDir | Out-Null
-    }
-    catch {
-        Write-Error "Failed to install Microsoft.DiaSymReader.Pdb2Pdb. Consider adding https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json as an upstream to your nuget.config feed."
-        return
-    }
-    $pdb2pdbpath = "$baseDir/microsoft.diasymreader.pdb2pdb/$version/tools/Pdb2Pdb.exe"
+# This package originally comes from the https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json feed.
+# Add this feed as an upstream to whatever feed is in nuget.config if this step fails.
+$packageID = 'Microsoft.DiaSymReader.Pdb2Pdb'
+$packageVersion = '1.1.0-beta2-21101-01'
+try {
+    $pdb2pdbpath = & "$PSScriptRoot/Download-NuGetPackage.ps1" -PackageId $packageID -Version $packageVersion -Source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+}
+catch {
+    Write-Error "Failed to install $packageID. Consider adding https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json as an upstream to your nuget.config feed."
+    return
 }
 
+New-Item -ItemType Directory -Force -Path (Split-Path $OutputPath -Parent) | Out-Null
+
+$toolpath = "$pdb2pdbpath/tools/Pdb2Pdb.exe"
 $arguments = $DllPath, '/out', $OutputPath, '/nowarn', '0021'
 if ($PdbPath) {
     $arguments += '/pdb', $PdbPath
 }
 
-Write-Verbose "$pdb2pdbpath $arguments"
-& $pdb2pdbpath $arguments
+Write-Verbose "$toolpath $arguments"
+& $toolpath $arguments

--- a/tools/Download-NuGetPackage.ps1
+++ b/tools/Download-NuGetPackage.ps1
@@ -37,6 +37,17 @@ if (!(Test-Path $OutputDirectory)) { New-Item -ItemType Directory -Path $OutputD
 $OutputDirectory = (Resolve-Path $OutputDirectory).Path
 $ConfigFile = (Resolve-Path $ConfigFile).Path
 
+$packageIdLower = $PackageId.ToLower()
+$packageRoot = Join-Path $OutputDirectory $packageIdLower
+
+if ($Version) {
+    $predictedPackageDir = Join-Path $packageRoot $Version
+    if (Test-Path -Path $predictedPackageDir -PathType Container) {
+        Write-Output (Resolve-Path $predictedPackageDir).Path
+        return
+    }
+}
+
 $packageArg = $PackageId
 if ($Version) { $packageArg = "$PackageId@$Version" }
 
@@ -56,16 +67,13 @@ if ($downloadExitCode -ne 0) {
 }
 
 # Return the path to the downloaded package directory (dotnet package download uses lowercase id)
-$packageIdLower = $PackageId.ToLower()
 if ($Version) {
-    $packageRoot = Join-Path $OutputDirectory $packageIdLower
     $packageDir = Get-ChildItem -Path $packageRoot -Directory -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -ieq $Version } |
         Select-Object -First 1
     if ($packageDir) { $packageDir = $packageDir.FullName }
 } else {
     # When no version is specified, pick the most recently written version directory.
-    $packageRoot = Join-Path $OutputDirectory $packageIdLower
     $packageDir = Get-ChildItem -Path $packageRoot -Directory -ErrorAction SilentlyContinue |
         Sort-Object -Property LastWriteTimeUtc -Descending |
         Select-Object -First 1

--- a/tools/Download-NuGetPackage.ps1
+++ b/tools/Download-NuGetPackage.ps1
@@ -73,5 +73,5 @@ if ($Version) {
 if ($packageDir -and (Test-Path $packageDir)) {
     Write-Output $packageDir
 } else {
-    Write-Error "Package directory not found after download."
+    throw "Package directory not found after download. PackageId='$PackageId'; Version='$Version'; OutputDirectory='$OutputDirectory'; PackageRoot='$packageRoot'."
 }

--- a/tools/Get-ExternalSymbolFiles.ps1
+++ b/tools/Get-ExternalSymbolFiles.ps1
@@ -80,9 +80,36 @@ Function Get-SymbolsFromPackage($id, $version) {
     }
 }
 
+Function Get-PackageVersions() {
+    if ($script:PackageVersions) {
+        return $script:PackageVersions
+    }
+
+    $propsPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\Directory.Packages.props')).Path
+    $output = & dotnet build $propsPath -nologo -verbosity:quiet -getItem:PackageVersion 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to evaluate package versions from Directory.Packages.props.`n$($output | Out-String)"
+        return @{}
+    }
+
+    $jsonText = ($output | Out-String).Trim()
+    $jsonStart = $jsonText.IndexOf('{')
+    if ($jsonStart -lt 0) {
+        Write-Error 'Failed to locate JSON output from `dotnet build -getItem:PackageVersion`.'
+        return @{}
+    }
+
+    $packageVersions = @{}
+    foreach ($item in @((ConvertFrom-Json $jsonText.Substring($jsonStart)).Items.PackageVersion)) {
+        $packageVersions[$item.Identity] = $item.Version
+    }
+
+    $script:PackageVersions = $packageVersions
+    $packageVersions
+}
+
 Function Get-PackageVersion($id) {
-    $versionProps = [xml](Get-Content -LiteralPath $PSScriptRoot\..\Directory.Packages.props)
-    $version = $versionProps.Project.ItemGroup.PackageVersion | ? { $_.Include -eq $id } | % { $_.Version }
+    $version = Get-PackageVersions | Select-Object -ExpandProperty $id -ErrorAction SilentlyContinue
     if (!$version) {
         Write-Error "No package version found in Directory.Packages.props for the package '$id'"
     }

--- a/tools/Get-ExternalSymbolFiles.ps1
+++ b/tools/Get-ExternalSymbolFiles.ps1
@@ -25,11 +25,11 @@ Function Get-SymbolsFromPackage($id, $version) {
 
     # Download symbols for each binary using dotnet-symbol
     $serverArgs = $SymbolServers | ForEach-Object { '--server-path'; $_ }
-    $binaries = Get-ChildItem -Recurse -LiteralPath $packagePath -Include *.dll, *.exe
-    foreach ($binary in $binaries) {
+    $binaries = @(Get-ChildItem -Recurse -LiteralPath $packagePath -Include *.dll, *.exe)
+    if ($binaries) {
         $prevErrorActionPreference = $ErrorActionPreference
         $ErrorActionPreference = 'Continue'
-        & dotnet symbol --symbols @serverArgs --output $binary.DirectoryName $binary.FullName 2>&1 | Out-Null
+        & dotnet symbol --symbols @serverArgs @($binaries.FullName) 2>&1 | Out-Null
         $ErrorActionPreference = $prevErrorActionPreference
     }
 

--- a/tools/Get-ExternalSymbolFiles.ps1
+++ b/tools/Get-ExternalSymbolFiles.ps1
@@ -28,7 +28,12 @@ Function Get-SymbolsFromPackage($id, $version) {
     $unzippedPkgPath = Join-Path $symbolPackagesPath "$id.$version"
 
     # Download the package from configured feeds (failures are non-fatal for symbol collection)
-    & "$PSScriptRoot\Download-NuGetPackage.ps1" -PackageId $id -Version $version -OutputDirectory $symbolPackagesPath -ErrorAction SilentlyContinue | Out-Null
+    try {
+        & "$PSScriptRoot\Download-NuGetPackage.ps1" -PackageId $id -Version $version -OutputDirectory $symbolPackagesPath -ErrorAction SilentlyContinue | Out-Null
+    }
+    catch {
+        Write-Warning "Failed to download package $id $version from configured feeds. Skipping if not found locally. $($_.Exception.Message)"
+    }
     $global:LASTEXITCODE = 0
     $nupkgFile = Get-ChildItem -Recurse -Path $symbolPackagesPath -Filter "$id.$version.nupkg" -ErrorAction SilentlyContinue | Select-Object -First 1
     if (!$nupkgFile) {

--- a/tools/Get-ExternalSymbolFiles.ps1
+++ b/tools/Get-ExternalSymbolFiles.ps1
@@ -10,13 +10,14 @@ Function Get-SymbolsFromPackage($id, $version) {
     $packagePath = $null
 
     # Download the package from configured feeds (failures are non-fatal for symbol collection)
+    $previousLastExitCode = $global:LASTEXITCODE
     try {
         $packagePath = & "$PSScriptRoot\Download-NuGetPackage.ps1" -PackageId $id -Version $version -OutputDirectory $symbolPackagesPath -ErrorAction SilentlyContinue
     }
     catch {
         Write-Warning "Failed to download package $id $version from configured feeds. Skipping if not found locally. $($_.Exception.Message)"
     }
-    $global:LASTEXITCODE = 0
+    $global:LASTEXITCODE = $previousLastExitCode
     if (!$packagePath -or !(Test-Path -LiteralPath $packagePath)) {
         Write-Warning "Package $id $version not found in configured feeds. Skipping."
         return

--- a/tools/Get-ExternalSymbolFiles.ps1
+++ b/tools/Get-ExternalSymbolFiles.ps1
@@ -1,3 +1,7 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+Param (
+)
+
 # Symbol servers to search for PDBs, in order of priority.
 $SymbolServers = @(
     'https://msdl.microsoft.com/download/symbols'
@@ -106,6 +110,9 @@ $1stPartyPackageIds = @()
 $1stPartyPackageIds | % {
     $version = Get-PackageVersion $_
     if ($version) {
+        Write-Verbose "Downloading symbols for package '$_' version '$version'."
         Get-SymbolsFromPackage -id $_ -version $version
+    } else {
+        Write-Warning "No version found for package '$_'. Skipping symbol download."
     }
 }

--- a/tools/Get-ExternalSymbolFiles.ps1
+++ b/tools/Get-ExternalSymbolFiles.ps1
@@ -4,48 +4,27 @@ $SymbolServers = @(
     'https://symbols.nuget.org/download/symbols'
 )
 
-Function Unzip($Path, $OutDir) {
-    $OutDir = (New-Item -ItemType Directory -Path $OutDir -Force).FullName
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-    # Start by extracting to a temporary directory so that there are no file conflicts.
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($Path, "$OutDir.out")
-
-    # Now move all files from the temp directory to $OutDir, overwriting any files.
-    Get-ChildItem -Path "$OutDir.out" -Recurse -File | ForEach-Object {
-        $destinationPath = Join-Path -Path $OutDir -ChildPath $_.FullName.Substring("$OutDir.out".Length).TrimStart([io.path]::DirectorySeparatorChar, [io.path]::AltDirectorySeparatorChar)
-        if (!(Test-Path -Path (Split-Path -Path $destinationPath -Parent))) {
-            New-Item -ItemType Directory -Path (Split-Path -Path $destinationPath -Parent) | Out-Null
-        }
-        Move-Item -Path $_.FullName -Destination $destinationPath -Force
-    }
-    Remove-Item -Path "$OutDir.out" -Recurse -Force
-}
-
 Function Get-SymbolsFromPackage($id, $version) {
     $symbolPackagesPath = "$PSScriptRoot/../obj/SymbolsPackages"
     New-Item -ItemType Directory -Path $symbolPackagesPath -Force | Out-Null
-    $unzippedPkgPath = Join-Path $symbolPackagesPath "$id.$version"
+    $packagePath = $null
 
     # Download the package from configured feeds (failures are non-fatal for symbol collection)
     try {
-        & "$PSScriptRoot\Download-NuGetPackage.ps1" -PackageId $id -Version $version -OutputDirectory $symbolPackagesPath -ErrorAction SilentlyContinue | Out-Null
+        $packagePath = & "$PSScriptRoot\Download-NuGetPackage.ps1" -PackageId $id -Version $version -OutputDirectory $symbolPackagesPath -ErrorAction SilentlyContinue
     }
     catch {
         Write-Warning "Failed to download package $id $version from configured feeds. Skipping if not found locally. $($_.Exception.Message)"
     }
     $global:LASTEXITCODE = 0
-    $nupkgFile = Get-ChildItem -Recurse -Path $symbolPackagesPath -Filter "$id.$version.nupkg" -ErrorAction SilentlyContinue | Select-Object -First 1
-    if (!$nupkgFile) {
+    if (!$packagePath -or !(Test-Path -LiteralPath $packagePath)) {
         Write-Warning "Package $id $version not found in configured feeds. Skipping."
         return
     }
 
-    Unzip -Path $nupkgFile.FullName -OutDir $unzippedPkgPath
-
     # Download symbols for each binary using dotnet-symbol
     $serverArgs = $SymbolServers | ForEach-Object { '--server-path'; $_ }
-    $binaries = Get-ChildItem -Recurse -LiteralPath $unzippedPkgPath -Include *.dll, *.exe
+    $binaries = Get-ChildItem -Recurse -LiteralPath $packagePath -Include *.dll, *.exe
     foreach ($binary in $binaries) {
         $prevErrorActionPreference = $ErrorActionPreference
         $ErrorActionPreference = 'Continue'
@@ -54,7 +33,7 @@ Function Get-SymbolsFromPackage($id, $version) {
     }
 
     # Output pairs of binary + PDB paths for archival
-    Get-ChildItem -Recurse -LiteralPath $unzippedPkgPath -Filter *.pdb | % {
+    Get-ChildItem -Recurse -LiteralPath $packagePath -Filter *.pdb | % {
         $rootName = Join-Path $_.Directory $_.BaseName
         if ($rootName.EndsWith('.ni')) {
             $rootName = $rootName.Substring(0, $rootName.Length - 3)

--- a/tools/Get-NuGetTool.ps1
+++ b/tools/Get-NuGetTool.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    Downloads the NuGet.exe tool and returns the path to it.
+.PARAMETER NuGetVersion
+    The version of the NuGet tool to acquire.
+#>
+Param(
+    [Parameter()]
+    [string]$NuGetVersion='7.3.1'
+)
+
+function Test-NuGetExecutableSignature {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$Path
+    )
+
+    if (!(Test-Path $Path)) {
+        return $false
+    }
+
+    $signature = Get-AuthenticodeSignature -FilePath $Path
+    if ($signature.Status -eq [System.Management.Automation.SignatureStatus]::Valid -and
+        $null -ne $signature.SignerCertificate -and
+        $signature.SignerCertificate.Subject -like '*CN=Microsoft Corporation*') {
+        Write-Verbose "NuGet executable signature is valid."
+        return $true
+    }
+
+    Write-Verbose "NuGet executable signature is invalid."
+    return $false
+}
+
+$toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"
+$binaryToolsPath = Join-Path $toolsPath $NuGetVersion
+if (!(Test-Path $binaryToolsPath)) { $null = mkdir $binaryToolsPath }
+$nugetPath = Join-Path $binaryToolsPath nuget.exe
+
+if (!(Test-Path $nugetPath) -or -not (Test-NuGetExecutableSignature -Path $nugetPath)) {
+    Write-Host "Downloading nuget.exe $NuGetVersion..." -ForegroundColor Yellow
+    (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v$NuGetVersion/NuGet.exe", $nugetPath)
+
+    if (!(Test-NuGetExecutableSignature -Path $nugetPath)) {
+        Remove-Item $nugetPath -Force -ErrorAction SilentlyContinue
+        throw "Downloaded nuget.exe $NuGetVersion failed Authenticode signature validation."
+    }
+}
+
+return (Resolve-Path $nugetPath).Path

--- a/tools/Get-ProcDump.ps1
+++ b/tools/Get-ProcDump.ps1
@@ -2,11 +2,4 @@
 .SYNOPSIS
 Downloads 32-bit and 64-bit procdump executables and returns the path to where they were installed.
 #>
-$version = '0.0.1'
-$baseDir = "$PSScriptRoot\..\obj\tools"
-$procDumpToolPath = "$baseDir\procdump\$version\bin"
-if (-not (Test-Path $procDumpToolPath)) {
-    & "$PSScriptRoot\Download-NuGetPackage.ps1" -PackageId procdump -Version $version -OutputDirectory $baseDir | Out-Null
-}
-
-(Resolve-Path $procDumpToolPath).Path
+Join-Path (& "$PSScriptRoot\Download-NuGetPackage.ps1" -PackageId procdump -Version 0.0.1) 'bin'

--- a/tools/Install-NuGetPackage.ps1
+++ b/tools/Install-NuGetPackage.ps1
@@ -1,0 +1,85 @@
+<#
+.SYNOPSIS
+    Installs a NuGet package.
+.PARAMETER PackageID
+    The Package ID to install.
+.PARAMETER Version
+    The version of the package to install. If unspecified, the latest stable release is installed.
+.PARAMETER Source
+    The package source feed to find the package to install from.
+.PARAMETER Prerelease
+    Include prerelease packages when searching for the latest version.
+.PARAMETER ExcludeVersion
+    Installs the package without adding the version to the folder name.
+.PARAMETER DirectDownload
+    Bypass the local cache when downloading packages.
+.PARAMETER PackagesDir
+    The directory to install the package to. By default, it uses the Packages folder at the root of the repo.
+.PARAMETER ConfigFile
+    The nuget.config file to use. By default, it uses :/nuget.config.
+.OUTPUTS
+    System.String. The path to the installed package.
+#>
+[CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='Low')]
+Param(
+    [Parameter(Position=1,Mandatory=$true)]
+    [string]$PackageId,
+    [Parameter()]
+    [string]$Version,
+    [Parameter()]
+    [string]$Source,
+    [Parameter()]
+    [switch]$Prerelease,
+    [Parameter()]
+    [switch]$ExcludeVersion,
+    [Parameter()]
+    [switch]$DirectDownload,
+    [Parameter()]
+    [string]$PackagesDir="$PSScriptRoot\..\packages",
+    [Parameter()]
+    [string]$ConfigFile="$PSScriptRoot\..\nuget.config",
+    [Parameter()]
+    [ValidateSet('Quiet','Normal','Detailed')]
+    [string]$Verbosity='normal'
+)
+
+$nugetPath = & "$PSScriptRoot\Get-NuGetTool.ps1"
+
+Write-Verbose "Installing $PackageId..."
+$nugetArgs = "Install",$PackageId,"-OutputDirectory",$PackagesDir,'-ConfigFile',$ConfigFile
+if ($Version) { $nugetArgs += "-Version",$Version }
+if ($Source) { $nugetArgs += "-FallbackSource",$Source }
+if ($Prerelease) { $nugetArgs += "-Prerelease" }
+if ($ExcludeVersion) { $nugetArgs += '-ExcludeVersion' }
+if ($DirectDownload) { $nugetArgs += '-DirectDownload' }
+$nugetArgs += '-Verbosity',$Verbosity
+
+if ($PSCmdlet.ShouldProcess($PackageId, 'nuget install')) {
+    $p = Start-Process $nugetPath $nugetArgs -NoNewWindow -Wait -PassThru
+    if ($null -ne $p.ExitCode -and $p.ExitCode -ne 0) {
+        throw "NuGet install failed for package '$PackageId' (version '$requestedVersion') with exit code $exitCode."
+    }
+}
+
+# Provide the path to the installed package directory to our caller.
+if ($ExcludeVersion) {
+    $packageDir = Get-ChildItem -Path $PackagesDir -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ieq $PackageId } |
+        Select-Object -First 1
+} elseif ($Version) {
+    $expectedDirectoryName = "$PackageId.$Version"
+    $packageDir = Get-ChildItem -Path $PackagesDir -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ieq $expectedDirectoryName } |
+        Select-Object -First 1
+} else {
+    $packageDir = Get-ChildItem -Path $PackagesDir -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like "$PackageId.*" } |
+        Sort-Object -Property LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+}
+
+if ($packageDir -and (Test-Path -Path $packageDir.FullName -PathType Container)) {
+    Write-Output $packageDir.FullName
+} else {
+    throw "Installed package directory not found. PackageId='$PackageId'; Version='$Version'; ExcludeVersion='$ExcludeVersion'; PackagesDir='$PackagesDir'."
+}

--- a/tools/artifacts/VSInsertion.ps1
+++ b/tools/artifacts/VSInsertion.ps1
@@ -39,9 +39,9 @@ if (Test-Path $VsixPackages) {
 }
 
 if ($InsertionOutputs -and $env:PROFILINGINPUTSPROPSNAME) {
-    $InsertOutputsProfilingInputs = Join-Path $InsertionOutputs $env:PROFILINGINPUTSPROPSNAME
-    if (Test-Path -LiteralPath $InsertOutputsProfilingInputs) {
-        $result[$InsertionOutputs] = Get-ChildItem -LiteralPath $InsertOutputsProfilingInputs # OptProf ProfilingInputs
+    $InsertionOutputsProfilingInputs = Join-Path $InsertionOutputs $env:PROFILINGINPUTSPROPSNAME
+    if (Test-Path -LiteralPath $InsertionOutputsProfilingInputs) {
+        $result[$InsertionOutputs] = Get-ChildItem -LiteralPath $InsertionOutputsProfilingInputs # OptProf ProfilingInputs
     }
 }
 


### PR DESCRIPTION
*   Improve `dotnet symbol` performance
    
    We can invoke it just once with all the binaries we want symbols for.

*   Don't assume unpacked structure in Convert-PDB.ps1

*   Don't download a nuget package twice

*   Throw on Download-NuGetPackage errors (#507)
    
    Instead of writing an error and returning `$null` to the caller, we should do something that's harder to ignore.

*   Fix init.ps1 installation of local microbuild plugins
    
    We need the packages *with their dependencies* to be installed, and only
    
    I filed https://github.com/dotnet/sdk/issues/53890 to track this missing feature that requires us to go back to using nuget.exe.

*   Avoid stomping on LASTEXITCODE while simply trying to reset it

*   Avoid re-unzipping downloaded symbol packages
    
    Get-ExternalSymbolFiles.ps1 was downloading Nerdbank.Streams into obj/SymbolsPackages/nerdbank.streams/2.13.16 via Download-NuGetPackage.ps1, which uses dotnet package download. After that, the script searched for the .nupkg inside that directory and extracted it again into obj/SymbolsPackages/Nerdbank.Streams.2.13.16.
    
    That second extraction was redundant and only existed so dotnet symbol and the PDB archival logic had a package root to inspect. The downloaded package directory already contains the package contents in NuGet's normal lowercase layout, so the script can operate on that directory directly.
    
    Use the package path returned by Download-NuGetPackage.ps1 for symbol download and PDB discovery, and remove the extra unzip step. This leaves only one materialized package tree under obj/SymbolsPackages.

*   Improve resilience of fetching PackageVersion items

*   Add missing `dotnet symbol` command to manifest

*   Defend against exceptions thrown from `Download-NugetPackage.ps1`

*   Rename variable for better consistency

*   Throw on Download-NuGetPackage errors
    
    Instead of writing an error and returning `$null` to the caller, we should do something that's harder to ignore.

*   Update Dockerfile and global.json updates to v10.0.202 (506)
    
    Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>