### PR TITLE
Fix Install-DotNetSdk.ps1 hang from recursive Directory.Build.props search

### DIFF
--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -59,7 +59,9 @@ $runtimeVersions = @()
 $windowsDesktopRuntimeVersions = @()
 $aspnetRuntimeVersions = @()
 if (!$SdkOnly) {
-    Get-ChildItem "$PSScriptRoot\..\src\*.*proj", "$PSScriptRoot\..\test\*.*proj", "$PSScriptRoot\..\Directory.Build.props" -Recurse | % {
+    $projFiles = Get-ChildItem "$PSScriptRoot\..\src\*.*proj", "$PSScriptRoot\..\test\*.*proj" -Recurse
+    $projFiles += Get-Item -LiteralPath "$PSScriptRoot\..\Directory.Build.props"
+    $projFiles | % {
         $projXml = [xml](Get-Content -LiteralPath $_)
         $pg = $projXml.Project.PropertyGroup
         if ($pg) {

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -60,6 +60,7 @@ $windowsDesktopRuntimeVersions = @()
 $aspnetRuntimeVersions = @()
 if (!$SdkOnly) {
     $projFiles = Get-ChildItem "$PSScriptRoot\..\src\*.*proj", "$PSScriptRoot\..\test\*.*proj" -Recurse
+    $projFiles += Get-ChildItem "$PSScriptRoot\..\src\Directory.Build.props", "$PSScriptRoot\..\test\Directory.Build.props" -Recurse
     $projFiles += Get-Item -LiteralPath "$PSScriptRoot\..\Directory.Build.props"
     $projFiles | % {
         $projXml = [xml](Get-Content -LiteralPath $_)


### PR DESCRIPTION
The `Get-ChildItem` call applied `-Recurse` to all three path arguments, including `Directory.Build.props`. PowerShell splits this into container + leaf filter, so `-Recurse` causes it to search the entire repo root for every file named `Directory.Build.props`, crawling into large directories (`bin`, `obj`, `tmp`, etc.) and causing the script to hang in repos with deep directory trees.

**Fix:** Split the call so `-Recurse` only applies to the `src/` and `test/` project file globs. `Directory.Build.props` is fetched with `Get-Item -LiteralPath` (single file, no recursion, no wildcard interpretation).