### PR TITLE
Fix Codecov CLI publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
         }
       shell: pwsh
       timeout-minutes: 3
-      continue-on-error: true
 
   docs:
     name: 📃 Docs

--- a/tools/Get-CodeCovTool.ps1
+++ b/tools/Get-CodeCovTool.ps1
@@ -10,15 +10,15 @@ Param(
 )
 
 if ($IsMacOS) {
-    $codeCovUrl = "https://uploader.codecov.io/latest/macos/codecov"
+    $codeCovUrl = "https://cli.codecov.io/latest/macos/codecov"
     $toolName = 'codecov'
 }
 elseif ($IsLinux) {
-    $codeCovUrl = "https://uploader.codecov.io/latest/linux/codecov"
+    $codeCovUrl = "https://cli.codecov.io/latest/linux/codecov"
     $toolName = 'codecov'
 }
 else {
-    $codeCovUrl = "https://uploader.codecov.io/latest/windows/codecov.exe"
+    $codeCovUrl = "https://cli.codecov.io/latest/windows/codecov.exe"
     $toolName = 'codecov.exe'
 }
 
@@ -41,7 +41,7 @@ Function Get-FileFromWeb([Uri]$Uri, $OutDir) {
 }
 
 $toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"
-$binaryToolsPath = Join-Path $toolsPath codecov
+$binaryToolsPath = Join-Path $toolsPath codecov-cli
 $testingPath = Join-Path $binaryToolsPath unverified
 $finalToolPath = Join-Path $binaryToolsPath $toolName
 
@@ -52,13 +52,20 @@ if (!(Test-Path $finalToolPath)) {
     $tool = Get-FileFromWeb $codeCovUrl $testingPath
     $sha = Get-FileFromWeb "$codeCovUrl$shaSuffix" $testingPath
     $sig = Get-FileFromWeb "$codeCovUrl$sigSuffix" $testingPath
-    $key = Get-FileFromWeb https://keybase.io/codecovsecurity/pgp_keys.asc $testingPath
+    $key = Get-FileFromWeb https://keybase.io/codecovsecops/pgp_keys.asc $testingPath
 
     if ((Get-Command gpg -ErrorAction SilentlyContinue)) {
         Write-Host "Importing codecov key" -ForegroundColor Yellow
         gpg --import $key
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to import the Codecov signature verification key."
+        }
+
         Write-Host "Verifying signature on codecov hash" -ForegroundColor Yellow
         gpg --verify $sig $sha
+        if ($LASTEXITCODE -ne 0) {
+            throw "Codecov CLI signature verification failed."
+        }
     } else {
         if ($AllowSkipVerify) {
             Write-Warning "gpg not found. Unable to verify hash signature."

--- a/tools/publish-CodeCov.ps1
+++ b/tools/publish-CodeCov.ps1
@@ -21,10 +21,31 @@ Param (
 )
 
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
+$codeCovTool = & "$PSScriptRoot/Get-CodeCovTool.ps1"
 
 Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml" | % {
     $relativeFilePath = Resolve-Path -relative $_.FullName
 
     Write-Host "Uploading: $relativeFilePath" -ForegroundColor Yellow
-    & (& "$PSScriptRoot/Get-CodeCovTool.ps1") -t $CodeCovToken -f $relativeFilePath -R $RepoRoot -F $Flags -n $Name
+    $arguments = @(
+        "upload-process",
+        "--disable-search",
+        "--fail-on-error",
+        "-t", $CodeCovToken,
+        "-f", $relativeFilePath,
+        "--network-root-folder", $RepoRoot
+    )
+    if ($Flags) {
+        $arguments += @("-F", $Flags)
+    }
+
+    if ($Name) {
+        $arguments += @("-n", $Name)
+    }
+
+    & $codeCovTool $arguments
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Codecov CLI failed with exit code $LASTEXITCODE."
+        exit $LASTEXITCODE
+    }
 }


### PR DESCRIPTION
The retired Codecov uploader endpoints now return 404, while the workflow masked upload failures. This migrates coverage publishing to the supported Codecov CLI and makes upload failures fail the build.

- Download the platform-specific CLI from `cli.codecov.io` into a distinct cache, using the current Codecov signing key and explicit GPG failure checks while retaining signature and SHA verification.
- Invoke `upload-process` with explicit file discovery disabled, fail-on-error enabled, and optional flag/name arguments only when provided.
- Propagate the uploader's exact nonzero exit code and remove `continue-on-error` from the workflow step.

Validation included PowerShell parsing, a fresh signed CLI download and SHA verification, required `upload-process` argument checks, and exact propagation of exit code 37 from a fake uploader.